### PR TITLE
fix: close background page after recording

### DIFF
--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -6,25 +6,30 @@ import { MIMEType } from './mime'
 
 const timeslice = 3000 // 3s
 
-chrome.runtime.onMessage.addListener(async (message: Message) => {
-    try {
-        switch (message.type) {
-            case 'start-recording':
-                await startRecording(message.data)
-                return
-            case 'stop-recording':
-                await stopRecording()
-                return
-            case 'save-config-local':
-                Settings.setConfiguration(message.data)
-                return
-            case 'exception':
-                throw message.data
+chrome.runtime.onMessage.addListener((message: Message, sender: chrome.runtime.MessageSender, sendResponse: () => void) => {
+    (async () => {
+        try {
+            switch (message.type) {
+                case 'start-recording':
+                    await startRecording(message.data)
+                    return
+                case 'stop-recording':
+                    await stopRecording()
+                    return
+                case 'save-config-local':
+                    Settings.setConfiguration(message.data)
+                    return
+                case 'exception':
+                    throw message.data
+            }
+        } catch (e) {
+            sendException(e)
+            console.error(e)
+        } finally {
+            sendResponse()
         }
-    } catch (e) {
-        sendException(e)
-        console.error(e)
-    }
+    })()
+    return true // asynchronous flag
 })
 
 let recorder: MediaRecorder | undefined

--- a/src/service_worker.ts
+++ b/src/service_worker.ts
@@ -31,6 +31,8 @@ chrome.runtime.onInstalled.addListener(async () => {
         data: config as Configuration,
     }
     await chrome.runtime.sendMessage(msg)
+
+    await chrome.offscreen.closeDocument()
 })
 
 async function getOrCreateOffscreenDocument(): Promise<boolean> {
@@ -110,6 +112,7 @@ chrome.runtime.onMessage.addListener((message: Message, sender: chrome.runtime.M
                     return
                 case 'complete-recording':
                     await chrome.action.setIcon({ path: notRecordingIcon })
+                    await chrome.offscreen.closeDocument()
                     return
                 case 'save-config-sync':
                     await storage.set(Configuration.key, message.data)


### PR DESCRIPTION
Close unnecessary background pages to free up resources and apply updates quickly.