### PR TITLE
ci: use Node.js 22 and 24 in test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-22.04
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js
@@ -42,6 +43,7 @@ jobs:
   test:
     needs: [lint]
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     strategy:
       matrix:
         node-version: ["22.x", "24.x"] # Maintenance LTS, Active LTS


### PR DESCRIPTION
This pull request updates the Node.js versions used in the test workflow configuration to ensure compatibility with the latest LTS releases.

Test workflow configuration update:

* [`.github/workflows/test.yaml`](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L47-R47): Changed the Node.js matrix to test against versions `22.x` and `24.x` (previously `20.x` and `22.x`) to keep CI aligned with current LTS support.