### PR TITLE
feat(sentry): enhance logging and metrics for recording events

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Google Chrome Extensions Screen Recorder",
   "scripts": {
     "build": "webpack --mode=production",
-    "archive": "rm extension.zip && zip -r extension.zip extension",
+    "build:prod": "ENV_NAME=production webpack --mode=production && rm extension.zip && zip -r extension.zip extension",
     "watch": "webpack --mode=development -w",
     "lint": "eslint {src,*.{mjs,ts}}",
     "test": "jest"

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -41,6 +41,10 @@ export function isVideoRecordingMode(v: unknown): v is VideoRecordingMode {
 // Configuration type for sync storage (excludes device-specific settings)
 export type SyncConfiguration = Omit<Configuration, 'microphone' | 'cropping'>
 
+export type ReportConfiguration =
+    Pick<Configuration, 'windowSize' | 'screenRecordingSize' | 'videoFormat' | 'openOptionPage' | 'muteRecordingTab' | 'cropping'>
+    & { microphone: Omit<Microphone, 'deviceId'> }
+
 export class Configuration {
     public static readonly key = 'settings'
     windowSize: Resolution
@@ -100,6 +104,18 @@ export class Configuration {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { microphone: _m, cropping: _c, ...rest } = config
         return { ...rest }
+    }
+    static filterForReport(config: Configuration): ReportConfiguration {
+        const { windowSize, screenRecordingSize, videoFormat, openOptionPage, muteRecordingTab, microphone, cropping } = config
+        return {
+            windowSize,
+            screenRecordingSize,
+            videoFormat,
+            openOptionPage,
+            muteRecordingTab,
+            microphone: { enabled: microphone.enabled, gain: microphone.gain },
+            cropping,
+        }
     }
     static screenRecordingSize(screenRecordingSize: ScreenRecordingSize, base: Resolution): Resolution {
         if (screenRecordingSize.auto && base.width > 0 && base.height > 0) {

--- a/src/element/recordList.ts
+++ b/src/element/recordList.ts
@@ -91,7 +91,7 @@ export class RecordList extends LitElement {
                         return
                 }
             } catch (e) {
-                sendException(e)
+                sendException(e, { exceptionSource: 'option.recordList.onMessage' })
                 console.error(e)
             }
         })

--- a/src/sentry_event.ts
+++ b/src/sentry_event.ts
@@ -1,0 +1,33 @@
+export interface ExceptionMetadata {
+    exceptionSource: string;
+}
+
+export type Event = StartRecordingEvent | StopRecordingEvent | UnexpectedStopEvent;
+
+export interface StartRecordingEvent {
+    type: 'start_recording';
+    tags: {
+        state: {
+            opfsPersisted: boolean,
+        },
+    };
+}
+
+export interface StopRecordingEvent {
+    type: 'stop_recording';
+    metrics: {
+        recording: {
+            durationSec: number,
+            filesize: number,
+        },
+    };
+}
+
+export interface UnexpectedStopEvent {
+    type: 'unexpected_stop';
+    metrics: {
+        recording: {
+            durationSec: number,
+        },
+    };
+}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -3,6 +3,9 @@ import webpack from 'webpack'
 import Dotenv from 'dotenv-webpack'
 import pkg from './package.json'
 
+const envName = process.env.ENV_NAME === 'production' ? 'production' : 'develop'
+console.log(`${envName} build`)
+
 const config: webpack.Configuration = {
     entry: {
         offscreen: path.join(__dirname, 'src/offscreen.ts'),
@@ -33,6 +36,7 @@ const config: webpack.Configuration = {
         new Dotenv(),
         new webpack.DefinePlugin({
             'process.env.VERSION': `"${pkg.version}"`,
+            'process.env.ENV_NAME': `"${envName}"`,
         }),
     ],
 }


### PR DESCRIPTION
This pull request introduces significant improvements to error reporting, event logging, and build configuration for the Chrome extension. The main changes include enhanced Sentry integration with structured event and exception reporting, more detailed metrics and logs for recording events, and improved build scripts for production packaging. Additionally, error reporting now includes contextual metadata, and the configuration reporting is more precise.

**Error reporting and event logging enhancements:**

* Refactored Sentry integration in `src/sentry.ts` to use structured event types (`Event`) and exception metadata, enabling more granular logging of recording events and exceptions with context such as source and configuration details.
* Added new event types (`StartRecordingEvent`, `StopRecordingEvent`, `UnexpectedStopEvent`) and exception metadata interface in `src/sentry_event.ts`, supporting more detailed and typed telemetry.
* Updated exception handling throughout the codebase to include an `exceptionSource` for better traceability (e.g., in `src/offscreen.ts` and `src/element/recordList.ts`).

**Recording event metrics and logging:**

* Enhanced recording lifecycle events to log and report metrics such as recording duration, file size, and OPFS persistence status. These are now sent as structured events through Sentry and the new metrics logger.
* Improved logging granularity and consistency by switching from `console.log` to `console.info` or `console.warn` as appropriate, and by logging unexpected stops and errors with context.

**Configuration and build process improvements:**

* Added a new `ReportConfiguration` type and a `filterForReport` method in `src/configuration.ts` to control which configuration fields are reported with events, improving privacy and relevance of telemetry data.
* Updated the build process: introduced a new `build:prod` script in `package.json` that sets an environment variable for production builds, and ensured the environment name is available at runtime via `webpack.config.ts`.