### PR TITLE
fix(configuration): organizing settings to be included in reports

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -47,8 +47,9 @@ export function isVideoRecordingMode(v: unknown): v is VideoRecordingMode {
 export type SyncConfiguration = Omit<Configuration, 'microphone' | 'cropping'>
 
 export type ReportConfiguration =
-    Pick<Configuration, 'windowSize' | 'screenRecordingSize' | 'videoFormat' | 'openOptionPage' | 'muteRecordingTab' | 'cropping'>
+    Pick<Configuration, 'windowSize' | 'screenRecordingSize' | 'videoFormat' | 'openOptionPage' | 'muteRecordingTab' | 'recordingSortOrder'>
     & { microphone: Omit<Microphone, 'deviceId'> }
+    & { cropping: Pick<CroppingConfig, 'enabled'> & { region: Pick<CropRegion, 'width' | 'height'> } }
 
 export class Configuration {
     public static readonly key = 'settings'
@@ -113,7 +114,7 @@ export class Configuration {
         return { ...rest }
     }
     static filterForReport(config: Configuration): ReportConfiguration {
-        const { windowSize, screenRecordingSize, videoFormat, openOptionPage, muteRecordingTab, microphone, cropping } = config
+        const { windowSize, screenRecordingSize, videoFormat, openOptionPage, muteRecordingTab, microphone, cropping, recordingSortOrder } = config
         return {
             windowSize,
             screenRecordingSize,
@@ -121,7 +122,8 @@ export class Configuration {
             openOptionPage,
             muteRecordingTab,
             microphone: { enabled: microphone.enabled, gain: microphone.gain },
-            cropping,
+            cropping: { enabled: cropping.enabled, region: { width: cropping.region.width, height: cropping.region.height } },
+            recordingSortOrder,
         }
     }
     static screenRecordingSize(screenRecordingSize: ScreenRecordingSize, base: Resolution): Resolution {


### PR DESCRIPTION
This pull request refactors the cropping configuration in `src/configuration.ts` to simplify its structure and improve type safety. It also updates how cropping information is included in reporting and adds `recordingSortOrder` to the report configuration.

Configuration structure and type improvements:

* Renamed the `CroppingConfig` interface to `Cropping` and updated its usage throughout the codebase for consistency and clarity. [[1]](diffhunk://#diff-0931cf958317ce57b36bdf11695eaa9ce4ebeec0f9ae067343159a85d75732dfL11-R11) [[2]](diffhunk://#diff-0931cf958317ce57b36bdf11695eaa9ce4ebeec0f9ae067343159a85d75732dfL64-R65)
* Modified the `ReportConfiguration` type to include only the relevant cropping fields (`enabled`, `width`, `height`) and added the `recordingSortOrder` property.
* Updated the `filterForReport` method to extract and format cropping and recording sort order information according to the new structure.