### PR TITLE
feat(metrics): add click metrics for external links in support section

### DIFF
--- a/src/element/support.ts
+++ b/src/element/support.ts
@@ -12,7 +12,7 @@ import { MdFilledSelect } from '@material/web/select/filled-select'
 import { MdSwitch } from '@material/web/switch/switch'
 import { Settings } from './settings'
 import { Configuration } from '../configuration'
-import { sendFeedback, FeedbackType, sendException } from '../sentry'
+import { sendFeedback, FeedbackType, sendException, sendEvent } from '../sentry'
 import Alert from './alert'
 
 const MAX_MESSAGE_LENGTH = 1000
@@ -134,7 +134,7 @@ export class Support extends LitElement {
             <h2>Review</h2>
             <div class="review-section">
                 <p>If you find this extension useful, please leave a review!</p>
-                <md-filled-tonal-button href="https://chromewebstore.google.com/detail/instant-tab-recorder/giebbnikpnedbdojlghnnegpfbgdecmi/reviews" target="_blank">
+                <md-filled-tonal-button href="https://chromewebstore.google.com/detail/instant-tab-recorder/giebbnikpnedbdojlghnnegpfbgdecmi/reviews" target="_blank" rel="noopener" @click=${this.handleReviewLink}>
                     Write a Review
                     <md-icon slot="icon">rate_review</md-icon>
                 </md-filled-tonal-button>
@@ -143,7 +143,7 @@ export class Support extends LitElement {
             <h2>Support Development</h2>
             <div class="support-section">
                 <p>Your support helps keep this extension maintained and improved. Every contribution motivates continued development!</p>
-                <a class="buymeacoffee-link" href="https://www.buymeacoffee.com/ww24" target="_blank">
+                <a class="buymeacoffee-link" href="https://www.buymeacoffee.com/ww24" target="_blank" rel="noopener" @click=${this.handleSupportLink}>
                     <img src="icons/buymeacoffee.png" alt="Buy Me a Coffee">
                 </a>
             </div>
@@ -262,6 +262,14 @@ export class Support extends LitElement {
         } finally {
             this.isSending = false
         }
+    }
+
+    private handleSupportLink() {
+        sendEvent({ type: 'click_external_link', tags: { link: 'support' } })
+    }
+
+    private handleReviewLink() {
+        sendEvent({ type: 'click_external_link', tags: { link: 'review' } })
     }
 }
 

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -81,6 +81,7 @@ const METRICS = {
     START: 'recording.start',
     DURATION: 'recording.duration',
     FILESIZE: 'recording.filesize',
+    EXTERNAL_LINK: 'external_link.click',
 }
 
 export function sendEvent(e: Event) {
@@ -114,6 +115,13 @@ export function sendEvent(e: Event) {
                 scope, unit: 'second',
             })
             logger.info(e.type, { ...flatten(e.metrics) }, { scope })
+            break
+
+        case 'click_external_link':
+            metrics.count(METRICS.EXTERNAL_LINK, 1, {
+                scope, attributes: { ...flatten(e.tags) },
+            })
+            logger.info(e.type, { ...flatten(e.tags) }, { scope })
             break
     }
 }

--- a/src/sentry_event.ts
+++ b/src/sentry_event.ts
@@ -2,7 +2,7 @@ export interface ExceptionMetadata {
     exceptionSource: string;
 }
 
-export type Event = StartRecordingEvent | StopRecordingEvent | UnexpectedStopEvent;
+export type Event = StartRecordingEvent | StopRecordingEvent | UnexpectedStopEvent | ClickExternalLinkEvent;
 
 export interface StartRecordingEvent {
     type: 'start_recording';
@@ -29,5 +29,12 @@ export interface UnexpectedStopEvent {
         recording: {
             durationSec: number,
         },
+    };
+}
+
+export interface ClickExternalLinkEvent {
+    type: 'click_external_link';
+    tags: {
+        link: 'support' | 'review',
     };
 }


### PR DESCRIPTION
This pull request adds analytics tracking for external link clicks in the support page, allowing the application to log when users click on the "Buy Me a Coffee" or "Write a Review" links. The changes include new event types, updated event handling, and modifications to the UI components to trigger these events.

**Analytics & Event Tracking Enhancements:**

* Added a new `ClickExternalLinkEvent` type to the `Event` union and defined its structure in `sentry_event.ts` to track clicks on external links ("support" and "review"). [[1]](diffhunk://#diff-6ca84d646b1a82b4aac35c8ba23450de850383bcffdff4eecac6bc4860dc9355L5-R5) [[2]](diffhunk://#diff-6ca84d646b1a82b4aac35c8ba23450de850383bcffdff4eecac6bc4860dc9355R34-R40)
* Updated the `sendEvent` function in `sentry.ts` to handle the new `click_external_link` event, incrementing metrics and logging details when these links are clicked.
* Introduced a new metric key `EXTERNAL_LINK` for external link click events in the `METRICS` object in `sentry.ts`.

**UI Component Updates:**

* Modified the "Write a Review" button and "Buy Me a Coffee" link in `support.ts` to trigger analytics events via new click handlers (`handleReviewLink` and `handleSupportLink`). [[1]](diffhunk://#diff-63d5e19d778540c181ca18a5ede44d7ebba9b5d343d430b2843bb2b17872c931L137-R137) [[2]](diffhunk://#diff-63d5e19d778540c181ca18a5ede44d7ebba9b5d343d430b2843bb2b17872c931L146-R146)
* Implemented the `handleSupportLink` and `handleReviewLink` methods in `Support` to send the appropriate event when each external link is clicked.

**Imports & Integration:**

* Updated imports in `support.ts` to include the new `sendEvent` function.