### PR TITLE
fix(offscreen): stop MediaRecorder before removing tracks to prevent InvalidModificationError

### DIFF
--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -198,6 +198,9 @@ async function startRecording(startRecording: StartRecording) {
         const [tabTrack] = tabMedia.getTracks()
         tabTrack?.addEventListener('ended', () => {
             console.debug(`tabTrack.readyState: ${tabTrack.readyState}, tabMedia.active: ${tabMedia.active}`)
+            // Stop the MediaRecorder before removing tracks.
+            // Otherwise, it will get the error "InvalidModificationError: Tracks in MediaStream were removed."
+            recorder?.stop()
             tabMedia.getTracks().forEach(track => tabMedia.removeTrack(track))
             console.debug(`tabMedia.active: ${tabMedia.active}`)
         })


### PR DESCRIPTION
This pull request introduces a minor but important fix to the recording logic in `src/offscreen.ts`. The change ensures that the `MediaRecorder` is stopped before removing tracks from the media stream, which prevents an "InvalidModificationError" from occurring.

* Stop the `MediaRecorder` before removing tracks from the media stream in the `startRecording` function to avoid "InvalidModificationError".