### PR TITLE
feat(recording): enhance recording state management and metadata

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -318,4 +318,8 @@ export class Configuration {
 
         return migrated
     }
+
+    static filename(startAtMs: number, ext: string) {
+        return `video-${startAtMs}${ext}`
+    }
 };

--- a/src/element/recordList.ts
+++ b/src/element/recordList.ts
@@ -28,6 +28,7 @@ export interface RecordEntry {
     size: number;
     selected: boolean;
     recordedAt?: Date;
+    isRecording: boolean;
 }
 
 /**
@@ -70,6 +71,9 @@ export class RecordList extends LitElement {
         }
         .sort-chip {
             min-width: 90px;
+        }
+        .recording {
+            color: #d93025;
         }
     `
 
@@ -114,8 +118,6 @@ export class RecordList extends LitElement {
         try {
             switch (message.type) {
                 case 'recording-state':
-                    // Update UI when recording completed
-                    if (message.isRecording) return
                     await this.updateRecord()
                     await this.updateEstimate()
                     return
@@ -133,11 +135,14 @@ export class RecordList extends LitElement {
             return html`
             ${idx > 0 ? html`<md-divider></md-divider>` : ''}
             <md-list-item class="list-item">
-                <md-checkbox touch-target="wrapper" slot="start" ?checked=${record.selected} @input=${this.selectRecord(record)}></md-checkbox>
-                <a href="${downloadUrl}">${record.title}</a>
+                <md-checkbox touch-target="wrapper" slot="start" ?disabled=${record.isRecording} ?checked=${record.selected} @input=${this.selectRecord(record)}></md-checkbox>
+                ${record.isRecording
+                    ? html`<span aria-disabled="true">${record.title}</span>`
+                    : html`<a href="${downloadUrl}">${record.title}</a>`}
                 <div class="meta" title="file size"><md-icon>storage</md-icon> ${formatNum(record.size / 1024 / 1024, 2)} MB</div>
                 ${record.recordedAt != null ? html`<div class="meta" title="recorded at"><md-icon>schedule</md-icon> ${RecordList.dateTimeFormat.format(record.recordedAt)}</div>` : ''}
-                <md-filled-icon-button slot="end" @click=${this.playRecord(record)}>
+                ${record.isRecording ? html`<div class="meta recording" title="recording"><md-icon>screen_record</md-icon> Recording</div>` : ''}
+                <md-filled-icon-button slot="end" ?disabled=${record.isRecording} @click=${this.playRecord(record)}>
                     <md-icon>play_arrow</md-icon>
                 </md-filled-icon-button>
             </md-list-item>`
@@ -177,11 +182,14 @@ export class RecordList extends LitElement {
         // Fetch recordings from API
         const recordings = await recordingApi.listRecordings({ sort: this.sortOrder })
 
-        const result: Array<RecordEntry> = recordings.map(meta => ({
+        const result: Array<RecordEntry> = recordings.filter(meta => {
+            return !meta.isRecording || meta.isTemporary
+        }).map(meta => ({
             title: meta.title,
             size: meta.size,
             selected: false,
             recordedAt: meta.recordedAt != null ? new Date(meta.recordedAt) : undefined,
+            isRecording: meta.isRecording ?? false,
         }))
 
         const oldVal = [...this.records]
@@ -231,6 +239,7 @@ export class RecordList extends LitElement {
         const selected = e.target.selected
         const oldVal = [...this.records]
         this.records = this.records.map(record => {
+            if (record.isRecording) return record // ignore recording entry
             record.selected = selected
             return record
         })

--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -1,4 +1,5 @@
 import { parseApiPath, handleApiRequest } from './handler'
+import { RecordingState } from './handler'
 import type { RecordingStorage, RecordingMetadata, StorageEstimateInfo, ListRecordingsOptions } from './storage'
 
 // ---------- helpers ----------
@@ -65,7 +66,8 @@ describe('handleApiRequest – storage-estimate', () => {
             estimate: jest.fn<Promise<StorageEstimateInfo>, []>().mockResolvedValue({ usage: 1024, quota: 1048576 }),
         })
         const req = new Request('https://ext.example/api/storage/estimate')
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(200)
         expect(res.headers.get('Content-Type')).toBe('application/json')
@@ -75,7 +77,8 @@ describe('handleApiRequest – storage-estimate', () => {
     it('should return 405 for POST', async () => {
         const storage = createMockStorage()
         const req = new Request('https://ext.example/api/storage/estimate', { method: 'POST' })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(405)
     })
@@ -85,8 +88,17 @@ describe('handleApiRequest – storage-estimate', () => {
 
 describe('handleApiRequest – recordings-list', () => {
     const recordings: RecordingMetadata[] = [
-        { title: 'a.webm', size: 100, lastModified: 1, mimeType: 'video/webm', recordedAt: 1 },
-        { title: 'b.webm', size: 200, lastModified: 2, mimeType: 'video/webm', recordedAt: 2 },
+        { title: 'a.webm', size: 100, lastModified: 1, mimeType: 'video/webm', recordedAt: 1, isTemporary: false },
+        { title: 'b.webm', size: 200, lastModified: 2, mimeType: 'video/webm', recordedAt: 2, isTemporary: false },
+        { title: 'c.webm', size: 0, lastModified: 3, mimeType: 'video/webm', recordedAt: 3, isTemporary: false },
+        { title: 'c.webm.crswap', size: 0, lastModified: 3, mimeType: 'video/webm', recordedAt: 3, isTemporary: true },
+    ]
+    const recordingState: RecordingState = { isRecording: true, startAtMs: 3 }
+    const expected: RecordingMetadata[] = [
+        { title: 'a.webm', size: 100, lastModified: 1, mimeType: 'video/webm', recordedAt: 1, isTemporary: false, isRecording: false },
+        { title: 'b.webm', size: 200, lastModified: 2, mimeType: 'video/webm', recordedAt: 2, isTemporary: false, isRecording: false },
+        { title: 'c.webm', size: 0, lastModified: 3, mimeType: 'video/webm', recordedAt: 3, isTemporary: false, isRecording: true },
+        { title: 'c.webm.crswap', size: 0, lastModified: 3, mimeType: 'video/webm', recordedAt: 3, isTemporary: true, isRecording: true },
     ]
 
     it('should list recordings on GET', async () => {
@@ -94,10 +106,10 @@ describe('handleApiRequest – recordings-list', () => {
             list: jest.fn<Promise<RecordingMetadata[]>, [ListRecordingsOptions?]>().mockResolvedValue(recordings),
         })
         const req = new Request('https://ext.example/api/recordings')
-        const res = await handleApiRequest(req, storage)
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(200)
-        expect(await res.json()).toEqual(recordings)
+        expect(await res.json()).toEqual(expected)
         expect(storage.list).toHaveBeenCalledWith({ sort: 'asc' })
     })
 
@@ -106,7 +118,7 @@ describe('handleApiRequest – recordings-list', () => {
             list: jest.fn<Promise<RecordingMetadata[]>, [ListRecordingsOptions?]>().mockResolvedValue(recordings),
         })
         const req = new Request('https://ext.example/api/recordings?sort=desc')
-        const res = await handleApiRequest(req, storage)
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(200)
         expect(storage.list).toHaveBeenCalledWith({ sort: 'desc' })
@@ -115,7 +127,7 @@ describe('handleApiRequest – recordings-list', () => {
     it('should return 405 for DELETE', async () => {
         const storage = createMockStorage()
         const req = new Request('https://ext.example/api/recordings', { method: 'DELETE' })
-        const res = await handleApiRequest(req, storage)
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(405)
     })
@@ -130,7 +142,8 @@ describe('handleApiRequest – recording GET (full response)', () => {
             getFile: jest.fn<Promise<File | null>, [string]>().mockResolvedValue(file),
         })
         const req = new Request('https://ext.example/api/recordings/test.webm')
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(200)
         expect(res.headers.get('Content-Type')).toBe('video/webm')
@@ -145,7 +158,8 @@ describe('handleApiRequest – recording GET (full response)', () => {
             getFile: jest.fn<Promise<File | null>, [string]>().mockResolvedValue(file),
         })
         const req = new Request('https://ext.example/api/recordings/my%20video.mp4?download=true')
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(200)
         expect(res.headers.get('Content-Disposition')).toContain('attachment')
@@ -154,7 +168,8 @@ describe('handleApiRequest – recording GET (full response)', () => {
     it('should return 404 when file not found', async () => {
         const storage = createMockStorage()
         const req = new Request('https://ext.example/api/recordings/missing.webm')
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(404)
     })
@@ -162,7 +177,8 @@ describe('handleApiRequest – recording GET (full response)', () => {
     it('should return 405 for PUT', async () => {
         const storage = createMockStorage()
         const req = new Request('https://ext.example/api/recordings/test.webm', { method: 'PUT' })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(405)
     })
@@ -174,7 +190,8 @@ describe('handleApiRequest – recording DELETE', () => {
     it('should return 204 on successful delete', async () => {
         const storage = createMockStorage()
         const req = new Request('https://ext.example/api/recordings/test.webm', { method: 'DELETE' })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(204)
         expect(storage.delete).toHaveBeenCalledWith('test.webm')
@@ -200,7 +217,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm', {
             headers: { 'Range': 'bytes=0-4' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(206)
         expect(res.headers.get('Content-Range')).toBe(`bytes 0-4/${file.size}`)
@@ -216,7 +234,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm', {
             headers: { 'Range': 'bytes=-3' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(206)
         expect(res.headers.get('Content-Range')).toBe(`bytes 7-9/${file.size}`)
@@ -230,7 +249,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm', {
             headers: { 'Range': 'bytes=5-' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(206)
         expect(res.headers.get('Content-Range')).toBe(`bytes 5-9/${file.size}`)
@@ -244,7 +264,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm', {
             headers: { 'Range': 'bytes=0-99999' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(206)
         expect(res.headers.get('Content-Range')).toBe(`bytes 0-9/${file.size}`)
@@ -255,7 +276,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm', {
             headers: { 'Range': 'bytes=100-200' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(416)
         expect(res.headers.get('Content-Range')).toBe(`bytes */${file.size}`)
@@ -265,7 +287,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm', {
             headers: { 'Range': 'invalid' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(200)
         expect(res.headers.get('Accept-Ranges')).toBe('bytes')
@@ -276,7 +299,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm', {
             headers: { 'Range': 'items=0-5' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(200)
     })
@@ -285,7 +309,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm?download=true', {
             headers: { 'Range': 'bytes=0-4' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(206)
         expect(res.headers.get('Content-Disposition')).toContain('attachment')
@@ -295,7 +320,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm', {
             headers: { 'Range': 'bytes=0-0' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(206)
         expect(res.headers.get('Content-Range')).toBe(`bytes 0-0/${file.size}`)
@@ -309,7 +335,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm', {
             headers: { 'Range': 'bytes=9-9' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(206)
         expect(res.headers.get('Content-Range')).toBe(`bytes 9-9/${file.size}`)
@@ -323,7 +350,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm', {
             headers: { 'Range': 'bytes=0-2,5-7' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(206)
         const contentType = res.headers.get('Content-Type')!
@@ -349,7 +377,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm', {
             headers: { 'Range': 'bytes=0-1,4-5,8-9' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(206)
         const contentType = res.headers.get('Content-Type')!
@@ -370,7 +399,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm', {
             headers: { 'Range': 'bytes=100-200,300-400' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(416)
         expect(res.headers.get('Content-Range')).toBe(`bytes */${file.size}`)
@@ -380,7 +410,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm', {
             headers: { 'Range': 'bytes=0-2,100-200,7-9' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(206)
         const contentType = res.headers.get('Content-Type')!
@@ -397,7 +428,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm', {
             headers: { 'Range': 'bytes=0-2,100-200' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(206)
         // Should be a single-range response, not multipart
@@ -413,7 +445,8 @@ describe('handleApiRequest – recording GET (Range Requests)', () => {
         const req = new Request('https://ext.example/api/recordings/test.webm', {
             headers: { 'Range': 'bytes=0-2,5-7' },
         })
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(206)
         expect(res.headers.get('Accept-Ranges')).toBe('bytes')
@@ -426,7 +459,8 @@ describe('handleApiRequest – not found', () => {
     it('should return 404 for unknown API path', async () => {
         const storage = createMockStorage()
         const req = new Request('https://ext.example/api/unknown')
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(404)
     })
@@ -440,7 +474,8 @@ describe('handleApiRequest – internal error', () => {
             list: jest.fn<Promise<RecordingMetadata[]>, [ListRecordingsOptions?]>().mockRejectedValue(new Error('disk error')),
         })
         const req = new Request('https://ext.example/api/recordings')
-        const res = await handleApiRequest(req, storage)
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState)
 
         expect(res.status).toBe(500)
         expect(await res.json()).toEqual({ error: 'Internal Server Error' })

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -9,6 +9,7 @@ import type { RecordingStorage } from './storage'
 import { getMimeTypeFromExtension } from './mime'
 import { parseRangeHeader, resolveByteRange, generateBoundary, buildMultipartByteRangesBody } from './range'
 import type { ResolvedRange } from './range'
+import type { Resolution } from './configuration'
 
 const API_PREFIX = '/api/'
 
@@ -51,6 +52,12 @@ export function parseApiPath(pathname: string): { route: string; name?: string }
     return null
 }
 
+export interface RecordingState {
+    isRecording: boolean;
+    startAtMs?: number;
+    screenSize?: Resolution;
+}
+
 /**
  * Handle API requests for recording storage
  *
@@ -60,7 +67,7 @@ export function parseApiPath(pathname: string): { route: string; name?: string }
  * - GET  /api/recordings/:name       - Download recording (with Range Request support)
  * - DELETE /api/recordings/:name     - Delete recording
  */
-export async function handleApiRequest(request: Request, storage: RecordingStorage): Promise<Response> {
+export async function handleApiRequest(request: Request, storage: RecordingStorage, state: RecordingState): Promise<Response> {
     const url = new URL(request.url)
     const parsed = parseApiPath(url.pathname)
 
@@ -97,7 +104,10 @@ export async function handleApiRequest(request: Request, storage: RecordingStora
                 // Parse sort query parameter
                 const sortParam = url.searchParams.get('sort')
                 const sort = sortParam === 'desc' ? 'desc' : 'asc'
-                const recordings = await storage.list({ sort })
+                const recordings = (await storage.list({ sort })).map(r => ({
+                    ...r,
+                    isRecording: state.isRecording && state.startAtMs != null && r.recordedAt === state.startAtMs,
+                }))
                 return new Response(JSON.stringify(recordings), {
                     status: 200,
                     headers: { 'Content-Type': 'application/json' },

--- a/src/message.ts
+++ b/src/message.ts
@@ -27,6 +27,7 @@ export interface StartRecordingMessage {
     data: StartRecording;
 }
 export interface StartRecording {
+    startAtMs: number; // unix timestamp [ms]
     tabSize: Resolution;
     streamId: string;
 }

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -4,7 +4,7 @@ import {
     MediaStreamVideoTrackSource,
     MediaStreamAudioTrackSource,
 } from 'mediabunny'
-import { resolveBitrate, createOutputFormat, hasVideo, hasAudio } from './configuration'
+import { Configuration, resolveBitrate, createOutputFormat, hasVideo, hasAudio, containerExtension } from './configuration'
 import { Settings } from './element/settings'
 import type {
     Message,
@@ -16,7 +16,6 @@ import type {
     UpdateCropRegionMessage,
 } from './message'
 import { sendEvent, sendException } from './sentry'
-import { containerExtension } from './configuration'
 import { Preview } from './preview'
 import { Crop } from './crop'
 
@@ -165,7 +164,7 @@ async function startRecording(startRecording: StartRecording) {
     // Prepare output file
     const dirHandle = await navigator.storage.getDirectory()
     const ext = containerExtension(videoFormat.container)
-    const fileName = `video-${Date.now()}${ext}`
+    const fileName = Configuration.filename(startRecording.startAtMs, ext)
     recordingFileHandle = await dirHandle.getFileHandle(fileName, { create: true })
     const writableStream = await recordingFileHandle.createWritable()
 
@@ -289,7 +288,7 @@ async function startRecording(startRecording: StartRecording) {
     ]
 
     // Start output
-    recordingStartTime = Date.now()
+    recordingStartTime = startRecording.startAtMs
     await output.start()
 
     const outputMimeType = await output.getMimeType()

--- a/src/opfs_storage.ts
+++ b/src/opfs_storage.ts
@@ -75,6 +75,7 @@ export class OPFSStorage implements RecordingStorage {
             lastModified: file.lastModified,
             mimeType: getMimeTypeFromExtension(name),
             recordedAt,
+            isTemporary: name.endsWith('.crswap'), // Chrome swap file
         }
     }
 }

--- a/src/service_worker.ts
+++ b/src/service_worker.ts
@@ -13,16 +13,13 @@ import { Configuration, Resolution } from './configuration'
 import { ExtensionSyncStorage } from './storage'
 import { deepMerge } from './element/util'
 import { OPFSStorage } from './opfs_storage'
-import { handleApiRequest } from './handler'
+import { handleApiRequest, RecordingState } from './handler'
 
 const recordingIcon = '/icons/recording.png'
 const recordingVideoOnlyIcon = '/icons/recording-video-only.png'
 const recordingAudioOnlyIcon = '/icons/recording-audio-only.png'
 const notRecordingIcon = '/icons/not-recording.png'
 const storage = new ExtensionSyncStorage()
-
-// Track recording state for preview functionality
-let currentScreenSize: Resolution | null = null
 
 const CONTEXT_MENU_ID = 'start-recording'
 
@@ -64,12 +61,6 @@ async function getOffscreenDocument(): Promise<chrome.runtime.ExtensionContext |
     return existingContexts.find(c => c.contextType === 'OFFSCREEN_DOCUMENT')
 }
 
-
-async function isRecording(): Promise<boolean> {
-    const offscreenDocument = await getOffscreenDocument()
-    return offscreenDocument?.documentUrl?.endsWith('#recording') ?? false
-}
-
 async function createOffscreenDocument() {
     const offscreenDocument = await getOffscreenDocument()
     if (offscreenDocument) return
@@ -82,10 +73,30 @@ async function createOffscreenDocument() {
     })
 }
 
+async function getIsRecording(): Promise<boolean> {
+    const offscreenDocument = await getOffscreenDocument()
+    return offscreenDocument?.documentUrl?.endsWith('#recording') ?? false
+}
+
+// Persistent recording state
+const recordingStateKey = 'recordingState'
+async function getRecordingState(): Promise<RecordingState> {
+    const isRecording = await getIsRecording()
+    if (!isRecording) return { isRecording }
+
+    const recordingState = (await chrome.storage.local.get(recordingStateKey))[recordingStateKey]
+    if (!recordingState) return { isRecording }
+
+    return { ...recordingState, isRecording }
+}
+async function setRecordingState(state: RecordingState) {
+    await chrome.storage.local.set({ [recordingStateKey]: state })
+}
+
 // Action icon handler
 chrome.action.onClicked.addListener(async (tab: chrome.tabs.Tab) => {
     try {
-        if (await isRecording()) {
+        if (await getIsRecording()) {
             await stopRecording()
             return
         }
@@ -105,7 +116,7 @@ chrome.contextMenus.onClicked.addListener(async (info: chrome.contextMenus.OnCli
     if (info.menuItemId !== CONTEXT_MENU_ID || !tab) return
 
     try {
-        if (await isRecording()) {
+        if (await getIsRecording()) {
             await stopRecording()
             return
         }
@@ -126,17 +137,17 @@ chrome.commands.onCommand.addListener(async (command: string, tab?: chrome.tabs.
         switch (command) {
             case 'start-recording': {
                 if (!tab) return
-                if (await isRecording()) return
+                if (await getIsRecording()) return
                 await startRecording(tab)
                 break
             }
             case 'stop-recording': {
-                if (!(await isRecording())) return
+                if (!(await getIsRecording())) return
                 await stopRecording()
                 break
             }
             case 'toggle-recording': {
-                if (await isRecording()) {
+                if (await getIsRecording()) {
                     await stopRecording()
                     return
                 }
@@ -168,13 +179,20 @@ async function startRecording(tab: chrome.tabs.Tab) {
     })
 
     // Track screen size for preview functionality
-    currentScreenSize = { width: tab.width ?? 0, height: tab.height ?? 0 }
+    const screenSize = { width: tab.width ?? 0, height: tab.height ?? 0 }
+    const startAtMs = Date.now()
+    await setRecordingState({
+        isRecording: true,
+        startAtMs,
+        screenSize,
+    })
 
     // Send the stream ID to the offscreen document to start recording.
     const msg: StartRecordingMessage = {
         type: 'start-recording',
         data: {
-            tabSize: currentScreenSize,
+            startAtMs: startAtMs,
+            tabSize: screenSize,
             streamId,
         },
     }
@@ -197,8 +215,6 @@ async function stopRecording() {
     // Update action icon
     await chrome.action.setIcon({ path: notRecordingIcon })
 
-    // Update recording state and broadcast to option pages
-    currentScreenSize = null
     await broadcastRecordingState()
 
     // Update context menu title
@@ -216,7 +232,7 @@ async function stopRecording() {
 async function updateContextMenuTitle() {
     try {
         await chrome.contextMenus.update(CONTEXT_MENU_ID, {
-            title: (await isRecording()) ? 'Stop Recording' : 'Start Recording',
+            title: (await getIsRecording()) ? 'Stop Recording' : 'Start Recording',
         })
     } catch (e) {
         console.error('Failed to update context menu:', e)
@@ -225,10 +241,11 @@ async function updateContextMenuTitle() {
 
 // Broadcast recording state to all option pages
 async function broadcastRecordingState() {
+    const { screenSize } = await getRecordingState()
     const msg: RecordingStateMessage = {
         type: 'recording-state',
-        isRecording: await isRecording(),
-        screenSize: currentScreenSize ?? undefined,
+        isRecording: await getIsRecording(),
+        screenSize,
     }
     try {
         await chrome.runtime.sendMessage(msg)
@@ -342,6 +359,8 @@ self.addEventListener('fetch', (event: FetchEvent) => {
 
     // Only intercept /api/* requests from the same origin
     if (url.origin === location.origin && url.pathname.startsWith(API_PREFIX)) {
-        event.respondWith(handleApiRequest(event.request, recordingStorage))
+        event.respondWith((async () => {
+            return handleApiRequest(event.request, recordingStorage, await getRecordingState())
+        })())
     }
 })

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -14,6 +14,8 @@ export interface RecordingMetadata {
     lastModified: number
     mimeType: string
     recordedAt?: number
+    isRecording?: boolean
+    isTemporary: boolean
 }
 
 /**


### PR DESCRIPTION
This pull request introduces improvements to the handling and display of recording states in the video recording UI and API. The main focus is on preventing user actions on recordings that are currently in progress, enhancing UI feedback, and ensuring test coverage reflects these changes.

**UI/UX Improvements for Recording State:**

* Added an `isRecording` property to the `RecordEntry` interface and integrated it into the UI, disabling actions (checkbox selection and playback) for entries that are actively recording and visually indicating their status. (`src/element/recordList.ts`) [[1]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3R31) [[2]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L136-R143) [[3]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3R75-R77)
* Updated logic to prevent selection changes and filter out non-temporary recordings that are still being recorded from the record list. (`src/element/recordList.ts`) [[1]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L180-R190) [[2]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3R240)

**API and Testing Consistency:**

* Modified all relevant tests to supply a `recordingState` parameter to `handleApiRequest`, ensuring that API behavior is consistent with the new recording state logic. (`src/handler.test.ts`) [[1]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L68-R69) [[2]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L88-R100) [[3]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L109-R113) [[4]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L118-R123) [[5]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L133-R139) [[6]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L148-R155) [[7]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L157-R174) [[8]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L177-R187) [[9]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L203-R214) [[10]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L219-R231) [[11]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L233-R246) [[12]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L247-R261) [[13]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L258-R273) [[14]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L268-R284) [[15]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L279-R296) [[16]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L288-R306) [[17]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L298-R317) [[18]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L312-R332) [[19]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L326-R347) [[20]](diffhunk://#diff-e4ef95c01fb7d209d5087ce6db6181ac59662fd784583d5e8f95ecbaa8471414L352-R374)

**Utility Enhancement:**

* Added a static `filename` method to the `Configuration` class for consistent video file naming based on recording start time and extension. (`src/configuration.ts`)

**Code Cleanup:**

* Removed unnecessary conditional in the recording-state message handler, ensuring UI updates always occur when the recording state changes. (`src/element/recordList.ts`)