### PR TITLE
feat(recording): add trigger field to start and stop recording messages

### DIFF
--- a/src/message.ts
+++ b/src/message.ts
@@ -22,9 +22,14 @@ export interface ExceptionMessage {
     data: unknown;
 }
 
+export type Trigger = 'action-icon' | 'context-menu' | 'keyboard-shortcut' | 'tab-track-ended'
+
+export type StartTrigger = Exclude<Trigger, 'tab-track-ended'>
+
 export interface StartRecordingMessage {
     type: 'start-recording';
     data: StartRecording;
+    trigger: StartTrigger;
 }
 export interface StartRecording {
     startAtMs: number; // unix timestamp [ms]
@@ -43,6 +48,7 @@ export interface TabTrackEndedMessage {
 
 export interface StopRecordingMessage {
     type: 'stop-recording';
+    trigger: Trigger;
 }
 
 export interface ResizeWindowMessage {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -8,6 +8,8 @@ import { Configuration, resolveBitrate, createOutputFormat, hasVideo, hasAudio, 
 import { Settings } from './element/settings'
 import type {
     Message,
+    Trigger,
+    StartTrigger,
     StartRecording,
     UpdateRecordingIconMessage,
     TabTrackEndedMessage,
@@ -35,10 +37,10 @@ chrome.runtime.onMessage.addListener((message: Message, sender: chrome.runtime.M
         try {
             switch (message.type) {
                 case 'start-recording':
-                    await startRecording(message.data)
+                    await startRecording(message.trigger, message.data)
                     return
                 case 'stop-recording':
-                    await stopRecording()
+                    await stopRecording(message.trigger)
                     return
                 case 'save-config-local':
                     Settings.mergeRemoteConfiguration(message.data)
@@ -133,7 +135,7 @@ function createMixedMediaStream(tabStream: MediaStream, micStream: MediaStream |
     return finalStream
 }
 
-async function startRecording(startRecording: StartRecording) {
+async function startRecording(trigger: StartTrigger, startRecording: StartRecording) {
     if (output?.state === 'started') {
         throw new Error('Called startRecording while recording is in progress.')
     }
@@ -146,6 +148,7 @@ async function startRecording(startRecording: StartRecording) {
     sendEvent({
         type: 'start_recording',
         tags: {
+            trigger,
             state: {
                 opfsPersisted,
             },
@@ -319,7 +322,7 @@ async function startRecording(startRecording: StartRecording) {
     window.location.hash = 'recording'
 }
 
-async function stopRecording() {
+async function stopRecording(trigger: Trigger) {
     if (output == null) {
         window.location.hash = ''
         return
@@ -337,6 +340,7 @@ async function stopRecording() {
         await sendEvent({
             type: 'stop_recording',
             metrics: {
+                trigger,
                 recording: {
                     durationSec: duration / 1000,
                     filesize: file?.size ?? 0,

--- a/src/sentry_event.ts
+++ b/src/sentry_event.ts
@@ -1,3 +1,5 @@
+import type { StartTrigger, Trigger } from './message'
+
 export interface ExceptionMetadata {
     exceptionSource: string;
 }
@@ -7,6 +9,7 @@ export type Event = StartRecordingEvent | StopRecordingEvent | UnexpectedStopEve
 export interface StartRecordingEvent {
     type: 'start_recording';
     tags: {
+        trigger: StartTrigger,
         state: {
             opfsPersisted: boolean,
         },
@@ -16,6 +19,7 @@ export interface StartRecordingEvent {
 export interface StopRecordingEvent {
     type: 'stop_recording';
     metrics: {
+        trigger: Trigger,
         recording: {
             durationSec: number,
             filesize: number,

--- a/src/service_worker.ts
+++ b/src/service_worker.ts
@@ -3,6 +3,8 @@ import { v7 as uuidv7 } from 'uuid'
 import type { getMediaStreamId } from './type'
 import type {
     Message,
+    Trigger,
+    StartTrigger,
     StartRecordingMessage,
     StopRecordingMessage,
     SaveConfigLocalMessage,
@@ -95,12 +97,13 @@ async function setRecordingState(state: RecordingState) {
 
 // Action icon handler
 chrome.action.onClicked.addListener(async (tab: chrome.tabs.Tab) => {
+    const trigger = 'action-icon'
     try {
         if (await getIsRecording()) {
-            await stopRecording()
+            await stopRecording(trigger)
             return
         }
-        await startRecording(tab)
+        await startRecording(tab, trigger)
     } catch (e) {
         console.error(e)
         const msg: ExceptionMessage = {
@@ -114,13 +117,13 @@ chrome.action.onClicked.addListener(async (tab: chrome.tabs.Tab) => {
 // Context menu click handler
 chrome.contextMenus.onClicked.addListener(async (info: chrome.contextMenus.OnClickData, tab?: chrome.tabs.Tab) => {
     if (info.menuItemId !== CONTEXT_MENU_ID || !tab) return
-
+    const trigger = 'context-menu'
     try {
         if (await getIsRecording()) {
-            await stopRecording()
+            await stopRecording(trigger)
             return
         }
-        await startRecording(tab)
+        await startRecording(tab, trigger)
     } catch (e) {
         console.error(e)
         const msg: ExceptionMessage = {
@@ -133,26 +136,27 @@ chrome.contextMenus.onClicked.addListener(async (info: chrome.contextMenus.OnCli
 
 // Keyboard shortcut handler
 chrome.commands.onCommand.addListener(async (command: string, tab?: chrome.tabs.Tab) => {
+    const trigger = 'keyboard-shortcut'
     try {
         switch (command) {
             case 'start-recording': {
                 if (!tab) return
                 if (await getIsRecording()) return
-                await startRecording(tab)
+                await startRecording(tab, trigger)
                 break
             }
             case 'stop-recording': {
                 if (!(await getIsRecording())) return
-                await stopRecording()
+                await stopRecording(trigger)
                 break
             }
             case 'toggle-recording': {
                 if (await getIsRecording()) {
-                    await stopRecording()
+                    await stopRecording(trigger)
                     return
                 }
                 if (!tab) return
-                await startRecording(tab)
+                await startRecording(tab, trigger)
                 break
             }
             case 'open-option-page': {
@@ -170,7 +174,7 @@ chrome.commands.onCommand.addListener(async (command: string, tab?: chrome.tabs.
     }
 })
 
-async function startRecording(tab: chrome.tabs.Tab) {
+async function startRecording(tab: chrome.tabs.Tab, trigger: StartTrigger) {
     await createOffscreenDocument()
 
     // Get a MediaStream for the active tab.
@@ -190,6 +194,7 @@ async function startRecording(tab: chrome.tabs.Tab) {
     // Send the stream ID to the offscreen document to start recording.
     const msg: StartRecordingMessage = {
         type: 'start-recording',
+        trigger,
         data: {
             startAtMs: startAtMs,
             tabSize: screenSize,
@@ -205,10 +210,11 @@ async function startRecording(tab: chrome.tabs.Tab) {
     await updateContextMenuTitle()
 }
 
-async function stopRecording() {
+async function stopRecording(trigger: Trigger) {
     // Send stop-recording message to offscreen document
     const msg: StopRecordingMessage = {
         type: 'stop-recording',
+        trigger,
     }
     await chrome.runtime.sendMessage(msg)
 
@@ -277,7 +283,7 @@ chrome.runtime.onMessage.addListener((message: Message, sender: chrome.runtime.M
                 case 'tab-track-ended':
                     // Fire-and-forget: stopRecording closes the Offscreen Document,
                     // so it must not be awaited inside the message listener.
-                    stopRecording().catch(async e => {
+                    stopRecording('tab-track-ended').catch(async e => {
                         console.error(e)
                         const msg: ExceptionMessage = {
                             type: 'exception',


### PR DESCRIPTION
This pull request enhances the recording workflow by tracking and propagating the "trigger"—the user action that initiated or stopped a recording—throughout the extension. This enables more detailed analytics and debugging by recording whether actions were started by clicking the action icon, using the context menu, keyboard shortcuts, or automatically when a tab track ends.

**Trigger propagation and analytics improvements:**

* Introduced a new `Trigger` type and added a `trigger` field to `StartRecordingMessage` and `StopRecordingMessage`, ensuring the initiating action is always tracked and passed through the message pipeline. [[1]](diffhunk://#diff-60ea006d358dc5cddec873646d6aaae8ee58e5dcee845e71069a25b99ba126bbR25-R30) [[2]](diffhunk://#diff-60ea006d358dc5cddec873646d6aaae8ee58e5dcee845e71069a25b99ba126bbR48)
* Updated the event logging for `start_recording` and `stop_recording` events to include the `trigger`, allowing for more granular analytics in Sentry. [[1]](diffhunk://#diff-7edf71b8e6c0fbe3e02537c2de10da15c14bba6f87c0e0251b1697a55456a454R151) [[2]](diffhunk://#diff-7edf71b8e6c0fbe3e02537c2de10da15c14bba6f87c0e0251b1697a55456a454R343) [[3]](diffhunk://#diff-6ca84d646b1a82b4aac35c8ba23450de850383bcffdff4eecac6bc4860dc9355R10) [[4]](diffhunk://#diff-6ca84d646b1a82b4aac35c8ba23450de850383bcffdff4eecac6bc4860dc9355R20)

**Service worker and offscreen communication changes:**

* Modified all recording start/stop handlers (action icon, context menu, keyboard shortcuts, and tab track end) to set and forward the appropriate `trigger` value when sending messages to the offscreen document. [[1]](diffhunk://#diff-9a8dfe07c2bfeb25a7bcb4e293c44857c0bbbfc3417c31f1dc9d1d3482864216R88-R94) [[2]](diffhunk://#diff-9a8dfe07c2bfeb25a7bcb4e293c44857c0bbbfc3417c31f1dc9d1d3482864216L106-R114) [[3]](diffhunk://#diff-9a8dfe07c2bfeb25a7bcb4e293c44857c0bbbfc3417c31f1dc9d1d3482864216R127-R147) [[4]](diffhunk://#diff-9a8dfe07c2bfeb25a7bcb4e293c44857c0bbbfc3417c31f1dc9d1d3482864216L162-R165) [[5]](diffhunk://#diff-9a8dfe07c2bfeb25a7bcb4e293c44857c0bbbfc3417c31f1dc9d1d3482864216R179) [[6]](diffhunk://#diff-9a8dfe07c2bfeb25a7bcb4e293c44857c0bbbfc3417c31f1dc9d1d3482864216L190-R198) [[7]](diffhunk://#diff-9a8dfe07c2bfeb25a7bcb4e293c44857c0bbbfc3417c31f1dc9d1d3482864216L263-R268)
* Updated the offscreen document's recording functions (`startRecording`, `stopRecording`) to accept and utilize the `trigger` parameter, ensuring the value is consistently used throughout the recording lifecycle. [[1]](diffhunk://#diff-7edf71b8e6c0fbe3e02537c2de10da15c14bba6f87c0e0251b1697a55456a454L39-R43) [[2]](diffhunk://#diff-7edf71b8e6c0fbe3e02537c2de10da15c14bba6f87c0e0251b1697a55456a454L137-R138) [[3]](diffhunk://#diff-7edf71b8e6c0fbe3e02537c2de10da15c14bba6f87c0e0251b1697a55456a454L323-R325)

These changes provide better traceability for user actions, improve error reporting, and lay the groundwork for more detailed analytics and debugging in the extension.