### PR TITLE
bump: v1.4.0

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
     "name": "Instant Tab Recorder",
     "short_name": "Tab Recorder",
     "description": "Blazing simple tab recorder.",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "minimum_chrome_version": "140",
     "icons": {
         "16": "icons/icon16.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chrome-tab-recorder",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chrome-tab-recorder",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@material/web": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-tab-recorder",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Google Chrome Extensions Screen Recorder",
   "scripts": {
     "build": "webpack --mode=production",


### PR DESCRIPTION
This pull request updates the version number of the Instant Tab Recorder Chrome extension from 1.3.1 to 1.4.0 in both the extension manifest and the project package file.

Version bump:

* Updated the `version` field in `extension/manifest.json` from 1.3.1 to 1.4.0 to reflect a new release of the Chrome extension.
* Updated the `version` field in `package.json` from 1.3.1 to 1.4.0 to keep the project metadata in sync.