### PR TITLE
ci(dependabot): add mediabunny group patterns to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
       semver-major-days: 14
       semver-minor-days: 5
       semver-patch-days: 3
+    groups:
+      mediabunny:
+        patterns:
+          - mediabunny
+          - @mediabunny/*
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This pull request introduces a configuration change to Dependabot by grouping updates related to Mediabunny packages. This will help manage and consolidate dependency updates for Mediabunny and related packages.

Dependabot configuration improvements:

* Added a new group named `mediabunny` to the `.github/dependabot.yml` file, which will group updates for any dependencies matching `mediabunny` or `@mediabunny/*` patterns.