### PR TITLE
refactor(sentry): convert VideoFormat interface to class and enhance report generation

### DIFF
--- a/src/configuration.test.ts
+++ b/src/configuration.test.ts
@@ -5,7 +5,7 @@ jest.mock('@mediabunny/flac-encoder', () => ({
     registerFlacEncoder: jest.fn(),
 }))
 
-import { migrateFromMimeType } from './configuration'
+import { migrateFromMimeType, VideoFormat } from './configuration'
 
 describe('migrateFromMimeType', () => {
     describe('WebM container', () => {
@@ -106,6 +106,100 @@ describe('migrateFromMimeType', () => {
         it('should handle empty', () => {
             const result = migrateFromMimeType('')
             expect(result).toEqual({ container: 'webm', videoCodec: 'vp9', audioCodec: 'opus' })
+        })
+    })
+})
+
+describe('VideoFormat.toReport', () => {
+    const base: Omit<VideoFormat, 'recordingMode'> = {
+        container: 'webm',
+        audioCodec: 'opus',
+        audioBitratePreset: 'high',
+        audioBitrate: 256000,
+        audioSampleRate: 44100,
+        videoCodec: 'vp9',
+        videoBitratePreset: 'high',
+        videoBitrate: 8000000,
+        frameRate: 30,
+    }
+
+    it('should include all fields for video-and-audio mode', () => {
+        const vf: VideoFormat = { ...base, recordingMode: 'video-and-audio', audioBitratePreset: 'custom', videoBitratePreset: 'custom' }
+        expect(VideoFormat.toReport(vf)).toEqual({
+            recordingMode: 'video-and-audio',
+            container: 'webm',
+            audioCodec: 'opus',
+            audioBitratePreset: 'custom',
+            audioBitrate: 256000,
+            audioSampleRate: 44100,
+            videoCodec: 'vp9',
+            videoBitratePreset: 'custom',
+            videoBitrate: 8000000,
+            frameRate: 30,
+        })
+    })
+
+    it('should omit video fields for audio-only mode', () => {
+        const vf: VideoFormat = { ...base, recordingMode: 'audio-only' }
+        expect(VideoFormat.toReport(vf)).toEqual({
+            recordingMode: 'audio-only',
+            container: 'webm',
+            audioCodec: 'opus',
+            audioBitratePreset: 'high',
+            audioBitrate: undefined,
+            audioSampleRate: 44100,
+            videoCodec: undefined,
+            videoBitratePreset: undefined,
+            videoBitrate: undefined,
+            frameRate: undefined,
+        })
+    })
+
+    it('should omit audio fields for video-only mode', () => {
+        const vf: VideoFormat = { ...base, recordingMode: 'video-only' }
+        expect(VideoFormat.toReport(vf)).toEqual({
+            recordingMode: 'video-only',
+            container: 'webm',
+            audioCodec: undefined,
+            audioBitratePreset: undefined,
+            audioBitrate: undefined,
+            audioSampleRate: undefined,
+            videoCodec: 'vp9',
+            videoBitratePreset: 'high',
+            videoBitrate: undefined,
+            frameRate: 30,
+        })
+    })
+
+    it('should include custom audioBitrate when preset is custom', () => {
+        const vf: VideoFormat = { ...base, recordingMode: 'video-and-audio', audioBitratePreset: 'custom', audioBitrate: 128000 }
+        expect(VideoFormat.toReport(vf)).toEqual({
+            recordingMode: 'video-and-audio',
+            container: 'webm',
+            audioCodec: 'opus',
+            audioBitratePreset: 'custom',
+            audioBitrate: 128000,
+            audioSampleRate: 44100,
+            videoCodec: 'vp9',
+            videoBitratePreset: 'high',
+            videoBitrate: undefined,
+            frameRate: 30,
+        })
+    })
+
+    it('should include custom videoBitrate when preset is custom', () => {
+        const vf: VideoFormat = { ...base, recordingMode: 'video-and-audio', videoBitratePreset: 'custom', videoBitrate: 4000000 }
+        expect(VideoFormat.toReport(vf)).toEqual({
+            recordingMode: 'video-and-audio',
+            container: 'webm',
+            audioCodec: 'opus',
+            audioBitratePreset: 'high',
+            audioBitrate: undefined,
+            audioSampleRate: 44100,
+            videoCodec: 'vp9',
+            videoBitratePreset: 'custom',
+            videoBitrate: 4000000,
+            frameRate: 30,
         })
     })
 })

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -92,17 +92,59 @@ export function resolveBitrate(preset: BitratePreset, customValue: number): numb
     }
 }
 
-export interface VideoFormat {
-    audioBitrate: number; // bps (used when audioBitratePreset is 'custom')
-    audioBitratePreset: BitratePreset;
-    videoBitrate: number; // bps (used when videoBitratePreset is 'custom')
-    videoBitratePreset: BitratePreset;
-    audioSampleRate: number; // Hz
-    frameRate: number; // fps
-    container: ContainerFormat;
-    videoCodec: VideoCodecType;
-    audioCodec: AudioCodecType;
-    recordingMode: VideoRecordingMode;
+export class VideoFormat {
+    constructor(
+        public recordingMode: VideoRecordingMode,
+        public container: ContainerFormat,
+        public audioCodec: AudioCodecType,
+        public audioBitratePreset: BitratePreset,
+        public audioBitrate: number, // bps (used when audioBitratePreset is 'custom')
+        public audioSampleRate: number,
+        public videoCodec: VideoCodecType,
+        public videoBitratePreset: BitratePreset,
+        public videoBitrate: number, // bps (used when videoBitratePreset is 'custom')
+        public frameRate: number // fps
+    ) { }
+
+    static toReport(vf: VideoFormat): VideoFormatReport {
+        const report: VideoFormatReport = { ...vf }
+        const { recordingMode, audioBitratePreset, videoBitratePreset } = vf
+        switch (recordingMode) {
+            case 'audio-only':
+                report.videoCodec = undefined
+                report.videoBitratePreset = undefined
+                report.videoBitrate = undefined
+                report.frameRate = undefined
+                break
+            case 'video-only':
+                report.audioCodec = undefined
+                report.audioBitratePreset = undefined
+                report.audioBitrate = undefined
+                report.audioSampleRate = undefined
+                break
+        }
+        if (audioBitratePreset !== 'custom') {
+            report.audioBitrate = undefined
+        }
+        if (videoBitratePreset !== 'custom') {
+            report.videoBitrate = undefined
+        }
+        return report
+    }
+}
+
+export type VideoFormatReport = Pick<VideoFormat, 'recordingMode' | 'container'> & {
+    // audio
+    audioCodec?: AudioCodecType;
+    audioBitratePreset?: BitratePreset;
+    audioBitrate?: number; // bps (used when audioBitratePreset is 'custom')
+    audioSampleRate?: number; // Hz
+
+    // video
+    videoCodec?: VideoCodecType;
+    videoBitratePreset?: BitratePreset;
+    videoBitrate?: number; // bps (used when videoBitratePreset is 'custom')
+    frameRate?: number; // fps
 }
 
 /**
@@ -169,8 +211,9 @@ export function isAudioOnly(mode: VideoRecordingMode): boolean {
 // Configuration type for sync storage (excludes device-specific settings)
 export type SyncConfiguration = Omit<Configuration, 'microphone' | 'cropping'>
 
-export type ReportConfiguration =
-    Pick<Configuration, 'windowSize' | 'screenRecordingSize' | 'videoFormat' | 'openOptionPage' | 'muteRecordingTab' | 'recordingSortOrder'>
+export type ConfigurationReport =
+    Pick<Configuration, 'windowSize' | 'screenRecordingSize' | 'openOptionPage' | 'muteRecordingTab' | 'recordingSortOrder'>
+    & { videoFormat: VideoFormatReport }
     & { microphone: Omit<Microphone, 'deviceId'> }
     & { cropping: Pick<CroppingConfig, 'enabled'> & { region: Pick<CropRegion, 'width' | 'height'> } }
 
@@ -198,18 +241,18 @@ export class Configuration {
             auto: true,
             scale: 2,
         }
-        this.videoFormat = {
-            audioBitrate: 256 * 1000, // 256kbps
-            audioBitratePreset: 'high',
-            videoBitrate: 8 * 1000 * 1000, // 8mbps
-            videoBitratePreset: 'high',
-            audioSampleRate: 44100, // 44.1kHz
-            frameRate: 30, // 30fps
-            container: 'webm',
-            videoCodec: 'vp9',
-            audioCodec: 'opus',
-            recordingMode: 'video-and-audio',
-        }
+        this.videoFormat = new VideoFormat(
+            'video-and-audio', // recordingMode
+            'webm', // container
+            'opus', // audioCodec
+            'high', // audioBitratePreset
+            256 * 1000, // audioBitrate (256kbps)
+            44100, // audioSampleRate (44.1kHz)
+            'vp9', // videoCodec
+            'high', // videoBitratePreset
+            8 * 1000 * 1000, // videoBitrate (8mbps)
+            30, // frameRate (30fps)
+        )
         this.enableBugTracking = true
         this.updatedAt = 0
         this.userId = ''
@@ -241,19 +284,10 @@ export class Configuration {
         const { microphone: _m, cropping: _c, ...rest } = config
         return { ...rest }
     }
-    static filterForReport(config: Configuration): ReportConfiguration {
-        let { videoFormat, cropping, microphone } = config
+    static filterForReport(config: Configuration): ConfigurationReport {
+        let { cropping, microphone } = config
         // Normalize values to reduce cardinality
-        if (videoFormat.audioBitratePreset !== 'custom') {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { audioBitrate: _, ...rest } = videoFormat
-            videoFormat = { audioBitrate: 0, ...rest }
-        }
-        if (videoFormat.videoBitratePreset !== 'custom') {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { videoBitrate: _, ...rest } = videoFormat
-            videoFormat = { videoBitrate: 0, ...rest }
-        }
+        const videoFormat = VideoFormat.toReport(config.videoFormat)
         if (!cropping.enabled) {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { region: _, ...rest } = cropping

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -50,6 +50,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function flatten(obj: Record<string, unknown>, prefix = ''): Record<string, unknown> {
     const result: Record<string, unknown> = {}
     for (const [key, value] of Object.entries(obj)) {
+        if (value === undefined) continue
         const newKey = prefix ? `${prefix}.${key}` : key
         if (isRecord(value)) {
             Object.assign(result, flatten(value, newKey))


### PR DESCRIPTION
This pull request introduces a refactor of the `VideoFormat` type, converting it from a plain interface to a class with a new static method for reporting, and updates related configuration and reporting logic to use this new structure. It also adds comprehensive unit tests for the reporting logic and makes a minor improvement to the `flatten` utility to skip `undefined` values.

Key changes include:

### VideoFormat Refactor and Reporting

* Refactored `VideoFormat` from an interface to a class, adding a static `toReport` method that generates a report object with fields omitted based on the recording mode and bitrate presets. This improves encapsulation and makes reporting logic more robust and reusable.
* Introduced a new `VideoFormatReport` type, which is used for reporting and omits fields that are not relevant for the current recording mode or are set to default presets.
* Updated the `Configuration` class to instantiate `videoFormat` as a `VideoFormat` object and updated the `filterForReport` method to use the new `toReport` method for normalization. [[1]](diffhunk://#diff-0931cf958317ce57b36bdf11695eaa9ce4ebeec0f9ae067343159a85d75732dfL201-R253) [[2]](diffhunk://#diff-0931cf958317ce57b36bdf11695eaa9ce4ebeec0f9ae067343159a85d75732dfL244-R288)
* Changed the report type for configuration from `ReportConfiguration` to `ConfigurationReport`, reflecting the new structure and usage of `VideoFormatReport`.

### Testing

* Added a comprehensive test suite for `VideoFormat.toReport`, covering all recording modes and custom bitrate scenarios to ensure correct field omission and inclusion.

### Utility Improvements

* Modified the `flatten` function in `src/sentry.ts` to skip `undefined` values, preventing them from appearing in the flattened output.