### PR TITLE
ci(dependabot): Update dependabot.yml to use quotes for patterns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,8 @@ updates:
     groups:
       mediabunny:
         patterns:
-          - mediabunny
-          - @mediabunny/*
+          - "mediabunny"
+          - "@mediabunny/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This pull request makes a minor update to the `.github/dependabot.yml` configuration, changing the syntax of the patterns used for the `mediabunny` group to use quoted strings. This improves consistency and avoids potential parsing issues.