### PR TITLE
chore(workflows): pin action versions in GitHub workflows

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -28,14 +28,14 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: "package.json"
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-node-modules
         with:
@@ -49,11 +49,11 @@ jobs:
       - name: Build site
         run: npm run site:build
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: docs/dist
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,16 +10,16 @@ jobs:
         runs-on: ubuntu-22.04
         timeout-minutes: 5
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
             - name: Use Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
               with:
                   node-version-file: "package.json"
             - name: Cache node modules
               id: cache-npm
-              uses: actions/cache@v5
+              uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
               env:
                   cache-name: cache-node-modules
               with:
@@ -40,7 +40,7 @@ jobs:
               id: version
               run: echo "version=$(node -p 'require("./package.json").name + "@" + require("./package.json").version')" >> "$GITHUB_OUTPUT"
             - name: Create Sentry release
-              uses: getsentry/action-release@v3
+              uses: getsentry/action-release@dab6548b3c03c4717878099e43782cf5be654289 # v3.5.0
               env:
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
                   SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: "package.json"
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-node-modules
         with:
@@ -48,14 +48,14 @@ jobs:
       matrix:
         node-version: ["22.x", "24.x"] # Maintenance LTS, Active LTS
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
This pull request updates all GitHub Actions used in the project's workflow YAML files to pin them to specific commit SHAs instead of using version tags. This change improves security and reliability by ensuring that the exact version of each action is used, preventing unexpected updates.

**GitHub Actions hardening and pinning:**

* Updated `actions/checkout`, `actions/setup-node`, and `actions/cache` in `.github/workflows/pages.yaml`, `.github/workflows/release.yaml`, and `.github/workflows/test.yaml` to reference specific commit SHAs instead of version tags. [[1]](diffhunk://#diff-86eaae8c6d4108350f0ef9589ef2a19de3d6e3693eff3b89ee35c160ae35c21cL31-R38) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL13-R22) [[3]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L16-R23) [[4]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L51-R58)
* Updated `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages` in `.github/workflows/pages.yaml` to use specific commit SHAs.
* Updated `getsentry/action-release` in `.github/workflows/release.yaml` to a specific commit SHA.