### PR TITLE
chore(deps): add typescript-eslint group to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
         patterns:
           - "mediabunny"
           - "@mediabunny/*"
+      typescript-eslint:
+        patterns:
+          - "typescript-eslint"
+          - "@typescript-eslint/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This pull request adds configuration for Dependabot to monitor and update dependencies related to TypeScript ESLint. This will help keep our TypeScript linting tools up to date automatically.

Dependency update configuration:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R19-R22): Added a new group for `typescript-eslint` and `@typescript-eslint/*` packages to the Dependabot configuration.