### PR TITLE
fix: update record size calculation in confirmation dialog

### DIFF
--- a/src/element/confirm.ts
+++ b/src/element/confirm.ts
@@ -41,7 +41,7 @@ export default class Confirm extends LitElement {
             <md-list>
               ${this.records.map((record, i) => html`
                   ${i > 0 ? html`<md-divider></md-divider>` : html``}
-                  <md-list-item>${record.title} <div slot="end">(size: ${formatNum(record.size / 1024 / 1024, 2)} MB)</div></md-list-item>
+                  <md-list-item>${record.title} <div slot="end">(size: ${formatNum((record.size + record.subFilesSize) / 1024 / 1024, 2)} MB)</div></md-list-item>
               `)}
             </md-list>
           </form>


### PR DESCRIPTION
This pull request makes a small but important change to how file sizes are displayed in the confirmation dialog. Now, the displayed size for each record includes both the main file size and the size of any associated sub-files, giving users a more accurate total size.

- Updated the file size calculation in the `Confirm` component (`src/element/confirm.ts`) to include both `record.size` and `record.subFilesSize` when displaying the size for each record.