### PR TITLE
fix: synchronize manifest version with package version

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,8 +1,16 @@
+import fs from 'fs'
 import path from 'path'
 import webpack from 'webpack'
 import Dotenv from 'dotenv-webpack'
 import pkg from './package.json'
 import manifest from './extension/manifest.json'
+
+const manifestPath = path.join(__dirname, 'extension/manifest.json')
+if (manifest.version !== pkg.version) {
+    manifest.version = pkg.version
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 4) + '\n')
+    console.log(`Updated manifest.json version to ${pkg.version}`)
+}
 
 const envName = process.env.ENV_NAME === 'production' ? 'production' : 'develop'
 console.log(`${envName} build`)


### PR DESCRIPTION
This pull request updates the build process to ensure consistency between the extension's manifest and the package version. Now, whenever the webpack config runs, it checks if the version in `manifest.json` matches the version in `package.json` and updates it if necessary.

Build process improvements:

* Added logic to `webpack.config.ts` that automatically synchronizes the `version` field in `extension/manifest.json` with the version from `package.json`, writing changes to disk if needed. This helps prevent version mismatches between the manifest and the package metadata.