### PR TITLE
chore: add audio separation to configuration report

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -230,7 +230,7 @@ export function audioSeparationContainer(audioCodec: AudioCodecType): ContainerF
 }
 
 export type ConfigurationReport =
-    Pick<Configuration, 'windowSize' | 'screenRecordingSize' | 'openOptionPage' | 'muteRecordingTab' | 'recordingSortOrder'>
+    Pick<Configuration, 'windowSize' | 'screenRecordingSize' | 'openOptionPage' | 'muteRecordingTab' | 'recordingSortOrder' | 'audioSeparation'>
     & { videoFormat: VideoFormatReport }
     & { microphone: Omit<Microphone, 'deviceId'> }
     & { cropping: Pick<CroppingConfig, 'enabled'> & { region: Pick<CropRegion, 'width' | 'height'> } }
@@ -320,7 +320,7 @@ export class Configuration {
             const { gain: _, ...rest } = microphone
             microphone = { gain: 0, ...rest }
         }
-        const { windowSize, screenRecordingSize, openOptionPage, muteRecordingTab, recordingSortOrder } = config
+        const { windowSize, screenRecordingSize, openOptionPage, muteRecordingTab, recordingSortOrder, audioSeparation } = config
         return {
             windowSize,
             screenRecordingSize,
@@ -330,6 +330,7 @@ export class Configuration {
             microphone: { enabled: microphone.enabled, gain: microphone.gain },
             cropping: { enabled: cropping.enabled, region: { width: cropping.region.width, height: cropping.region.height } },
             recordingSortOrder,
+            audioSeparation,
         }
     }
     static screenRecordingSize(screenRecordingSize: ScreenRecordingSize, base: Resolution): Resolution {


### PR DESCRIPTION
This pull request updates the `ConfigurationReport` type and the `Configuration` class to include the `audioSeparation` property, ensuring that audio separation settings are properly reported and handled in the configuration export logic.

Configuration reporting improvements:

* Added the `audioSeparation` property to the `ConfigurationReport` type so that it is included in exported configuration reports.
* Updated the `Configuration.filterForReport()` method to extract and include the `audioSeparation` property from the configuration object. [[1]](diffhunk://#diff-0931cf958317ce57b36bdf11695eaa9ce4ebeec0f9ae067343159a85d75732dfL323-R323) [[2]](diffhunk://#diff-0931cf958317ce57b36bdf11695eaa9ce4ebeec0f9ae067343159a85d75732dfR333)