### PR TITLE
fix: update tagline and enhance feature descriptions in index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Instant Tab Recorder - Blazing Simple Tab Recorder</title>
+    <title>Instant Tab Recorder - Blazingly simple tab recorder</title>
     <meta name="description" content="Record any Chrome tab with just one click. Simple, fast, and privacy-focused.">
     <link rel="icon" type="image/png" href="icon128.png">
     <style>
@@ -434,7 +434,7 @@
         <div class="container">
             <img src="icon128.png" alt="" class="hero-icon">
             <h1>Instant Tab Recorder</h1>
-            <p class="tagline">Blazing simple tab recorder.</p>
+            <p class="tagline">Blazingly simple tab recorder.</p>
             <a href="https://chromewebstore.google.com/detail/instant-tab-recorder/giebbnikpnedbdojlghnnegpfbgdecmi"
                 class="cta-button" target="_blank" rel="noopener">
                 <svg viewBox="0 0 24 24" fill="currentColor">
@@ -457,28 +457,18 @@
                         <circle cx="12" cy="12" r="10"></circle>
                         <circle cx="12" cy="12" r="3"></circle>
                     </svg>
-                    <h3>One-Click Recording</h3>
-                    <p>Start recording any Chrome tab instantly with a single click. No complicated setup required.</p>
+                    <h3>Instant Recording</h3>
+                    <p>Start recording any Chrome tab instantly with a single click, context menu, or keyboard
+                        shortcut.</p>
                 </div>
                 <div class="feature">
                     <svg class="feature-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                         stroke-linecap="round" stroke-linejoin="round">
-                        <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-                        <line x1="9" y1="3" x2="9" y2="21"></line>
+                        <polygon points="23 7 16 12 23 17 23 7"></polygon>
+                        <rect x="1" y="5" width="15" height="14" rx="2" ry="2"></rect>
                     </svg>
-                    <h3>Context Menu Support</h3>
-                    <p>Right-click to start or stop recording. Perfect for popup windows and special tabs.</p>
-                </div>
-                <div class="feature">
-                    <svg class="feature-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                        stroke-linecap="round" stroke-linejoin="round">
-                        <circle cx="12" cy="12" r="3"></circle>
-                        <path
-                            d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z">
-                        </path>
-                    </svg>
-                    <h3>Customizable Settings</h3>
-                    <p>Configure video resolution, bitrate, and output format (WebM/MP4) to match your needs.</p>
+                    <h3>Flexible Recording Modes</h3>
+                    <p>Choose from three modes: video with audio, video only, or audio only, to suit your needs.</p>
                 </div>
                 <div class="feature">
                     <svg class="feature-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -488,8 +478,9 @@
                         <line x1="12" y1="19" x2="12" y2="23"></line>
                         <line x1="8" y1="23" x2="16" y2="23"></line>
                     </svg>
-                    <h3>Microphone Recording</h3>
-                    <p>Optionally include microphone audio to add narration or commentary to your recordings.</p>
+                    <h3>Microphone & Audio Separation</h3>
+                    <p>Add microphone audio to your recording. Optionally save tab and mic audio as separate files for
+                        transcription or post-processing.</p>
                 </div>
                 <div class="feature">
                     <svg class="feature-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -503,27 +494,21 @@
                         <line x1="17" y1="17" x2="22" y2="17"></line>
                         <line x1="17" y1="7" x2="22" y2="7"></line>
                     </svg>
-                    <h3>Cropping Area</h3>
-                    <p>Define a specific area to record before starting.</p>
+                    <h3>Cropping & Window Resize</h3>
+                    <p>Crop a portion of the visible area or resize the browser window to a specific dimension before
+                        recording.</p>
                 </div>
                 <div class="feature">
                     <svg class="feature-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                         stroke-linecap="round" stroke-linejoin="round">
-                        <polygon points="23 7 16 12 23 17 23 7"></polygon>
-                        <rect x="1" y="5" width="15" height="14" rx="2" ry="2"></rect>
+                        <circle cx="12" cy="12" r="3"></circle>
+                        <path
+                            d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z">
+                        </path>
                     </svg>
-                    <h3>Video or Audio Only</h3>
-                    <p>Record video only, audio only, or both. Flexible options for any use case.</p>
-                </div>
-                <div class="feature">
-                    <svg class="feature-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                        stroke-linecap="round" stroke-linejoin="round">
-                        <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
-                        <line x1="8" y1="21" x2="16" y2="21"></line>
-                        <line x1="12" y1="17" x2="12" y2="21"></line>
-                    </svg>
-                    <h3>Window Resize</h3>
-                    <p>Resize the browser window to a specific dimension before recording for consistent output.</p>
+                    <h3>Customizable Settings</h3>
+                    <p>Configure resolution, bitrate, format, and codec. Wide range of codecs including H.265, AV1,
+                        AAC, FLAC, and more.</p>
                 </div>
                 <div class="feature">
                     <svg class="feature-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -559,14 +544,14 @@
                     <div class="step-number">2</div>
                     <div class="step-content">
                         <h3>Click to Record</h3>
-                        <p>Click the extension icon or right-click and select "Start Recording" to begin.</p>
+                        <p>Click the extension icon, use the context menu, or press a keyboard shortcut to begin.</p>
                     </div>
                 </div>
                 <div class="step">
                     <div class="step-number">3</div>
                     <div class="step-content">
                         <h3>Save & Share</h3>
-                        <p>Stop the recording and download your video in WebM or MP4 format.</p>
+                        <p>Stop the recording and download it in WebM or MP4 format.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This pull request updates the `docs/index.html` file to improve and clarify the feature descriptions and usage instructions for the Instant Tab Recorder extension. The changes focus on making the documentation more accurate, comprehensive, and user-friendly by consolidating features, updating terminology, and adding details about new capabilities.

Feature and description updates:

* Consolidated and updated feature descriptions: Combined previously separate features (like context menu support and keyboard shortcuts) into a single, clearer description for "One-Click Recording." Added details about flexible recording modes (video with audio, video only, audio only) and customizable settings, including support for multiple codecs. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL461-R471) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL506-R511)
* Enhanced audio features: Updated the microphone recording feature to highlight the ability to separate tab and mic audio into different files, supporting transcription and post-processing workflows.
* Improved cropping and window management: Merged cropping and window resizing into a single feature, allowing users to crop the visible area or resize the browser window before recording.

Usage instructions and copy improvements:

* Updated usage steps: Clarified that users can start recording via the extension icon, context menu, or keyboard shortcut, and updated the save/share instructions to refer to "recording" instead of just "video."
* Minor copy edit: Changed the tagline from "Blazing simple tab recorder." to "Blazingly simple tab recorder." for improved readability.