### PR TITLE
chore: add .npmrc with min-release-age configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3


### PR DESCRIPTION
This pull request introduces a small configuration change to the `.npmrc` file, setting a minimum release age for npm packages. This helps ensure that only packages older than three days can be installed, which can prevent issues with unstable or recently published packages.

- Set `min-release-age=3` in `.npmrc` to require packages to be at least three days old before installation.