### PR TITLE
chore: update workflow names and concurrency settings in YAML files

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Deploy LP to GitHub Pages
 
 on:
   push:
@@ -17,7 +17,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:
@@ -54,6 +54,6 @@ jobs:
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: docs/dist
-      - name: Deploy to GitHub Pages
+      - name: Deploy LP to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,13 @@
-name: Sentry Release
+name: Create Sentry Release
 
 on:
     push:
         tags:
             - "v*"
+
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: false
 
 jobs:
     release:
@@ -39,7 +43,7 @@ jobs:
             - name: Get version from package.json
               id: version
               run: echo "version=$(node -e 'import("./package.json",{with:{type:"json"}}).then(m=>process.stdout.write(m.default.name+"@"+m.default.version))')" >> "$GITHUB_OUTPUT"
-            - name: Create Sentry release
+            - name: Create Sentry Release
               uses: getsentry/action-release@dab6548b3c03c4717878099e43782cf5be654289 # v3.5.0
               env:
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: test
+name: Lint & Test
 
 on:
   push:
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/upload-cws.yaml
+++ b/.github/workflows/upload-cws.yaml
@@ -1,7 +1,11 @@
-name: Upload to Chrome Web Store
+name: Upload Package to Chrome Web Store
 
 on:
     workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: false
 
 jobs:
     upload:
@@ -47,7 +51,7 @@ jobs:
               env:
                   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
-            - name: Upload to Chrome Web Store
+            - name: Upload Package to Chrome Web Store
               run: node scripts/upload-cws.mjs
               env:
                   CWS_PUBLISHER_ID: ${{ secrets.CWS_PUBLISHER_ID }}


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to improve naming clarity and introduce concurrency controls, ensuring that workflows do not overlap and are easier to manage. The changes focus on standardizing workflow names, adding or updating `concurrency` groups, and making minor improvements to job and step names for better readability.

**Workflow naming and clarity improvements:**

* Standardized workflow names in `.github/workflows/pages.yaml`, `.github/workflows/release.yaml`, `.github/workflows/test.yaml`, and `.github/workflows/upload-cws.yaml` to be more descriptive and consistent. [[1]](diffhunk://#diff-86eaae8c6d4108350f0ef9589ef2a19de3d6e3693eff3b89ee35c160ae35c21cL1-R1) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL1-R11) [[3]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L1-R1) [[4]](diffhunk://#diff-53862354b74b1b412fa0586d6c53b615c5d1fa5b17ebf8aa9fddc0b84997e3efL1-R9)
* Improved job and step names for clarity, such as renaming the Chrome Web Store upload step.

**Concurrency controls:**

* Added or updated `concurrency` groups in all workflows to prevent overlapping runs, using unique group names based on the workflow or workflow and branch. This ensures only one instance of a workflow runs at a time for a given context. [[1]](diffhunk://#diff-86eaae8c6d4108350f0ef9589ef2a19de3d6e3693eff3b89ee35c160ae35c21cL20-R20) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL1-R11) [[3]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692R11-R14) [[4]](diffhunk://#diff-53862354b74b1b412fa0586d6c53b615c5d1fa5b17ebf8aa9fddc0b84997e3efL1-R9)

These changes help maintain CI/CD reliability and make workflow management easier for the team.