### PR TITLE
refactor: remove directory caching from FileManager

### DIFF
--- a/src/recorder/file_manager.test.ts
+++ b/src/recorder/file_manager.test.ts
@@ -82,13 +82,13 @@ describe('FileManager', () => {
         })
     })
 
-    describe('directory caching', () => {
-        test('calls getDirectory only once across multiple operations', async () => {
+    describe('directory access', () => {
+        test('calls getDirectory for each operation', async () => {
             const fm = new FileManager()
             await fm.createRecordingFile(1, 'webm')
             await fm.createAudioFile('test.ogg')
 
-            expect(navigator.storage.getDirectory).toHaveBeenCalledTimes(1)
+            expect(navigator.storage.getDirectory).toHaveBeenCalledTimes(2)
         })
     })
 })

--- a/src/recorder/file_manager.ts
+++ b/src/recorder/file_manager.ts
@@ -2,20 +2,11 @@ import type { ContainerFormat } from '../configuration'
 import { containerExtension, Configuration } from '../configuration'
 
 export class FileManager {
-    private dirHandle: FileSystemDirectoryHandle | undefined
-
-    private async getDirectory(): Promise<FileSystemDirectoryHandle> {
-        if (this.dirHandle == null) {
-            this.dirHandle = await navigator.storage.getDirectory()
-        }
-        return this.dirHandle
-    }
-
     /**
      * Create a recording file in OPFS and return its handle.
      */
     async createRecordingFile(startAtMs: number, container: ContainerFormat): Promise<FileSystemFileHandle> {
-        const dirHandle = await this.getDirectory()
+        const dirHandle = await navigator.storage.getDirectory()
         const ext = containerExtension(container)
         const fileName = Configuration.filename(startAtMs, ext)
         return dirHandle.getFileHandle(fileName, { create: true })
@@ -25,7 +16,7 @@ export class FileManager {
      * Create an audio separation file in OPFS.
      */
     async createAudioFile(fileName: string): Promise<FileSystemFileHandle> {
-        const dirHandle = await this.getDirectory()
+        const dirHandle = await navigator.storage.getDirectory()
         return dirHandle.getFileHandle(fileName, { create: true })
     }
 }


### PR DESCRIPTION
This pull request updates the `FileManager` class to simplify directory access logic and changes the caching behavior for directory handles. The most significant change is the removal of directory handle caching, resulting in `navigator.storage.getDirectory()` being called for each file operation. Corresponding tests have been updated to reflect this new behavior.

FileManager directory access changes:

* Removed the `dirHandle` property and the `getDirectory` method from `FileManager`, so that `navigator.storage.getDirectory()` is now called directly in both `createRecordingFile` and `createAudioFile` methods. [[1]](diffhunk://#diff-8ae1bfb0d6e8f836d4dcc3e272db54cd5c673fe97d05679d592ba64572529979L5-R9) [[2]](diffhunk://#diff-8ae1bfb0d6e8f836d4dcc3e272db54cd5c673fe97d05679d592ba64572529979L28-R19)

Test updates:

* Updated the test in `file_manager.test.ts` to expect `navigator.storage.getDirectory` to be called for each file operation, verifying that caching is no longer used.

Issues:

- #550