### PR TITLE
fix: enable source maps for development builds only

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "Google Chrome Extensions Screen Recorder",
   "scripts": {
-    "build": "vite build",
+    "build": "SOURCEMAP=1 vite build",
     "build:prod": "rm -f extension.zip && ENV_NAME=production vite build && zip -r extension.zip extension",
     "watch": "vite build --watch --mode development",
     "lint": "eslint {src,scripts,*.{mjs,ts}}",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig(({ mode }) => ({
                 chunkFileNames: '[name]-[hash].js',
             },
         },
-        sourcemap: true,
+        sourcemap: !!process.env.SOURCEMAP,
         minify: mode === 'production',
         target: 'chrome140',
     },


### PR DESCRIPTION
This pull request updates the build process to make source map generation configurable via an environment variable. The main impact is that source maps are now only generated if the `SOURCEMAP` environment variable is set, giving us more control over build outputs.

Build process improvements:

* The `build` script in `package.json` now sets `SOURCEMAP=1` to ensure source maps are generated during standard builds.
* The `sourcemap` option in `vite.config.ts` is now determined by the `SOURCEMAP` environment variable, allowing source map generation to be toggled as needed.