### PR TITLE
bump: v1.6.0

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Instant Tab Recorder",
     "short_name": "Tab Recorder",
-    "description": "Blazing simple tab recorder.",
+    "description": "Blazingly simple tab recorder.",
     "version": "1.6.0",
     "minimum_chrome_version": "140",
     "icons": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
     "name": "Instant Tab Recorder",
     "short_name": "Tab Recorder",
     "description": "Blazing simple tab recorder.",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "minimum_chrome_version": "140",
     "icons": {
         "16": "icons/icon16.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instant-tab-recorder",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instant-tab-recorder",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@material/web": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instant-tab-recorder",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Google Chrome Extensions Screen Recorder",
   "scripts": {


### PR DESCRIPTION
This pull request updates the version number of the Instant Tab Recorder Chrome extension from 1.5.0 to 1.6.0 in both the extension manifest and the `package.json` file.

Version bump:

* Updated the `version` field in `extension/manifest.json` to 1.6.0 to reflect the new release.
* Updated the `version` field in `package.json` to 1.6.0 for consistency with the extension manifest.