### PR TITLE
fix(message): fix inappropriate message handling

### DIFF
--- a/src/element/cropping.ts
+++ b/src/element/cropping.ts
@@ -91,20 +91,22 @@ export class Cropping extends LitElement {
         this.stopPreview()
     }
 
+    // NOTE: Must not return true or a truthy value (e.g. Promise from async function)
+    // to avoid interfering with sendMessage responses from other contexts.
     private handleMessage = (message: RecordingStateMessage) => {
-        if (message.type === 'recording-state') {
-            const wasRecording = this.isRecording
-            const state = message.data
-            this.isRecording = state.isRecording
-            this.screenSize = state.screenSize ?? null
+        if (message.type !== 'recording-state') return
 
-            // Update preview state based on recording state change
-            if (this.isTabActive) {
-                if (state.isRecording && !wasRecording) {
-                    this.startPreview()
-                } else if (!state.isRecording && wasRecording) {
-                    this.stopPreview()
-                }
+        const wasRecording = this.isRecording
+        const state = message.data
+        this.isRecording = state.isRecording
+        this.screenSize = state.screenSize ?? null
+
+        // Update preview state based on recording state change
+        if (this.isTabActive) {
+            if (state.isRecording && !wasRecording) {
+                this.startPreview()
+            } else if (!state.isRecording && wasRecording) {
+                this.stopPreview()
             }
         }
     }

--- a/src/element/croppingPreview.ts
+++ b/src/element/croppingPreview.ts
@@ -162,8 +162,11 @@ export class CroppingPreview extends LitElement {
         }
     }
 
-    private handleMessage = async (message: PreviewFrameMessage) => {
-        if (message.type === 'preview-frame' && message.image) {
+    // NOTE: Must not return true or a truthy value (e.g. Promise from async function)
+    // to avoid interfering with sendMessage responses from other contexts.
+    private handleMessage = (message: PreviewFrameMessage) => {
+        if (message.type !== 'preview-frame' || !message.image) return;
+        (async () => {
             this.recordingWidth = message.recordingSize.width
             this.recordingHeight = message.recordingSize.height
 
@@ -188,7 +191,9 @@ export class CroppingPreview extends LitElement {
             if (!this.hasPreview) {
                 this.hasPreview = true
             }
-        }
+        })().catch((error: unknown) => {
+            console.error('Failed to process preview frame', error)
+        })
     }
 
     // Calculate scale factor for preview display

--- a/src/element/recordList.ts
+++ b/src/element/recordList.ts
@@ -159,35 +159,33 @@ export class RecordList extends LitElement {
         this.stopElapsedTimer()
     }
 
-    private handleMessage = async (message: Message) => {
-        try {
-            switch (message.type) {
-                case 'recording-state': {
-                    const state = message.data
-                    if (state.isRecording && state.startAtMs != null) {
-                        this.recordingTotalPausedMs = state.totalPausedMs ?? 0
-                        if (state.isPaused) {
-                            this.recordingPaused = true
-                            this.pauseElapsedTimer(state.startAtMs)
-                        } else {
-                            this.recordingPaused = false
-                            this.startElapsedTimer(state.startAtMs)
-                        }
-                        this.recordingStopAtMs = state.stopAtMs ?? null
-                        this.updateTimerStopText()
-                    } else {
-                        this.stopElapsedTimer()
-                    }
-                    await this.updateRecord()
-                    await this.updateEstimate()
-                    await this.checkStoredRecordingError()
-                    return
+    // NOTE: Must not return true or a truthy value (e.g. Promise from async function)
+    // to avoid interfering with sendMessage responses from other contexts.
+    private handleMessage = (message: Message) => {
+        if (message.type !== 'recording-state') return;
+        (async () => {
+            const state = message.data
+            if (state.isRecording && state.startAtMs != null) {
+                this.recordingTotalPausedMs = state.totalPausedMs ?? 0
+                if (state.isPaused) {
+                    this.recordingPaused = true
+                    this.pauseElapsedTimer(state.startAtMs)
+                } else {
+                    this.recordingPaused = false
+                    this.startElapsedTimer(state.startAtMs)
                 }
+                this.recordingStopAtMs = state.stopAtMs ?? null
+                this.updateTimerStopText()
+            } else {
+                this.stopElapsedTimer()
             }
-        } catch (e) {
+            await this.updateRecord()
+            await this.updateEstimate()
+            await this.checkStoredRecordingError()
+        })().catch(e => {
             console.error(e)
             sendException(e, { exceptionSource: 'option.recordList.onMessage' })
-        }
+        })
     }
 
     private async checkStoredRecordingError() {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -68,7 +68,8 @@ chrome.runtime.onMessage.addListener((message: Message, _sender: chrome.runtime.
     if (resultPromise == null) return
 
     resultPromise.then(result => {
-        sendResponse(result.response)
+        if (result != null) sendResponse(result)
+        else sendResponse()
     }).catch(e => {
         console.error(e)
         sendException(e, {

--- a/src/offscreen_handler.ts
+++ b/src/offscreen_handler.ts
@@ -40,12 +40,6 @@ export interface OffscreenDeps {
     setLocationHash(hash: string): void
 }
 
-// ---------- result type ----------
-
-export interface HandleOffscreenMessageResult {
-    response?: StartRecordingResponse
-}
-
 // ---------- handler ----------
 
 export class OffscreenHandler {
@@ -55,7 +49,7 @@ export class OffscreenHandler {
 
     constructor(private readonly deps: OffscreenDeps) { }
 
-    handleMessage(message: Message): Promise<HandleOffscreenMessageResult> | null {
+    handleMessage(message: Message): Promise<StartRecordingResponse | void> | null {
         switch (message.type) {
             case 'start-recording':
                 return this.handleStartRecording(message.data, message.trigger)
@@ -84,7 +78,7 @@ export class OffscreenHandler {
     private async handleStartRecording(
         data: StartRecording,
         trigger: StartTrigger,
-    ): Promise<HandleOffscreenMessageResult> {
+    ): Promise<StartRecordingResponse> {
         const { videoFormat, recordingSize } = this.deps.getRecordingInfo(data.tabSize)
         const config = this.deps.getConfiguration()
 
@@ -115,10 +109,10 @@ export class OffscreenHandler {
         }
 
         this.deps.setLocationHash('recording')
-        return { response }
+        return response
     }
 
-    private async handleStopRecording(trigger: Trigger): Promise<HandleOffscreenMessageResult> {
+    private async handleStopRecording(trigger: Trigger): Promise<void> {
         try {
             const result = await this.deps.session.stop()
             if (result) {
@@ -141,10 +135,9 @@ export class OffscreenHandler {
             this.deps.setLocationHash('')
         }
         await this.deps.flush()
-        return {}
     }
 
-    private async handleCancelRecording(): Promise<HandleOffscreenMessageResult> {
+    private async handleCancelRecording(): Promise<void> {
         try {
             const durationMs = await this.deps.session.cancel()
             this.deps.sendEvent({
@@ -163,53 +156,46 @@ export class OffscreenHandler {
             this.deps.setLocationHash('')
         }
         await this.deps.flush()
-        return {}
     }
 
-    private async handlePreviewControl(action: 'start' | 'stop'): Promise<HandleOffscreenMessageResult> {
+    private async handlePreviewControl(action: 'start' | 'stop'): Promise<void> {
         if (action === 'start') {
             this.deps.session.startPreview()
         } else {
             this.deps.session.stopPreview()
         }
-        return {}
     }
 
-    private async handleUpdateCropRegion(region: CropRegion): Promise<HandleOffscreenMessageResult> {
+    private async handleUpdateCropRegion(region: CropRegion): Promise<void> {
         this.deps.session.updateCropRegion(region)
-        return {}
     }
 
-    private async handlePauseRecording(): Promise<HandleOffscreenMessageResult> {
+    private async handlePauseRecording(): Promise<void> {
         this.deps.session.pause()
         this.pauseRecordingTimer()
-        return {}
     }
 
-    private async handleResumeRecording(): Promise<HandleOffscreenMessageResult> {
+    private async handleResumeRecording(): Promise<void> {
         this.deps.session.resume()
         await this.resumeRecordingTimer()
-        return {}
     }
 
-    private async handleSaveConfigLocal(data: Configuration): Promise<HandleOffscreenMessageResult> {
+    private async handleSaveConfigLocal(data: Configuration): Promise<void> {
         this.deps.mergeRemoteConfiguration(data)
         await this.deps.flush()
-        return {}
     }
 
     private async handleUpdateRecordingTimer(
         enabled: boolean,
         durationMinutes: number,
-    ): Promise<HandleOffscreenMessageResult> {
-        if (this.deps.getLocationHash() !== '#recording') return {}
+    ): Promise<void> {
+        if (this.deps.getLocationHash() !== '#recording') return
         if (enabled && durationMinutes > 0) {
             this.setRecordingTimer(durationMinutes)
         } else {
             this.clearRecordingTimer()
         }
         await this.sendTimerUpdated()
-        return {}
     }
 
     // ---------- timer helpers ----------

--- a/src/service_worker.ts
+++ b/src/service_worker.ts
@@ -2,7 +2,6 @@ import { v7 as uuidv7 } from 'uuid'
 
 import type { getMediaStreamId } from './type'
 import type {
-    Message,
     Trigger,
     StartTrigger,
     StartRecordingMessage,
@@ -22,7 +21,7 @@ import { deepMerge } from './element/util'
 import { OPFSStorage } from './opfs_storage'
 import { handleApiRequest, RecordingState } from './handler'
 import { buildRecordingTitle } from './format'
-import { handleMessage, type ServiceWorkerDeps } from './service_worker_handler'
+import { createMessageListener, type ServiceWorkerDeps } from './service_worker_handler'
 
 const recordingIcon = '/icons/recording.png'
 const recordingVideoOnlyIcon = '/icons/recording-video-only.png'
@@ -419,44 +418,14 @@ const messageHandlerDeps: ServiceWorkerDeps = {
     storageSyncSet: (key, value) => storage.set(key, value),
 }
 
-chrome.runtime.onMessage.addListener((message: Message, sender: chrome.runtime.MessageSender, sendResponse: (response?: Configuration) => void) => {
-    (async () => {
-        const respond = (() => {
-            let responded = false
-            return (response?: Configuration) => {
-                if (responded) return
-                responded = true
-                sendResponse(response)
-            }
-        })()
-        try {
-            const result = await handleMessage(message, messageHandlerDeps)
-            if (result.response != null) {
-                respond(result.response)
-            }
-            if (result.fireAndForget != null) {
-                result.fireAndForget.catch(async e => {
-                    console.error(e)
-                    const msg: ExceptionMessage = {
-                        type: 'exception',
-                        data: e,
-                    }
-                    await chrome.runtime.sendMessage(msg)
-                })
-            }
-        } catch (e) {
-            console.error(e)
-            const msg: ExceptionMessage = {
-                type: 'exception',
-                data: e,
-            }
-            await chrome.runtime.sendMessage(msg)
-        } finally {
-            respond()
-        }
-    })()
-    return true // asynchronous flag
-})
+chrome.runtime.onMessage.addListener(createMessageListener(messageHandlerDeps, async (e) => {
+    console.error(e)
+    const msg: ExceptionMessage = {
+        type: 'exception',
+        data: e,
+    }
+    await chrome.runtime.sendMessage(msg)
+}))
 
 async function resizeWindow({ width, height }: Resolution) {
     const window = await chrome.windows.getCurrent()

--- a/src/service_worker_handler.ts
+++ b/src/service_worker_handler.ts
@@ -22,57 +22,111 @@ export interface ServiceWorkerDeps {
 }
 
 export type HandleMessageResult = {
-    response?: Configuration
-    fireAndForget?: Promise<void>
+    response: Promise<Configuration | void>
+    fireAndForget: boolean
 }
 
-export async function handleMessage(
+export function handleMessage(
     message: Message,
     deps: ServiceWorkerDeps,
-): Promise<HandleMessageResult> {
+): HandleMessageResult | null {
     switch (message.type) {
         case 'resize-window':
-            if (typeof message.data !== 'object' || message.data == null) return {}
-            await deps.resizeWindow(message.data)
-            return {}
+            return { response: handleResizeWindow(message, deps), fireAndForget: true }
         case 'recording-tick':
-            const state = await deps.getRecordingState()
-            await deps.updateActionTitle(state)
-            return {}
+            return { response: handleRecordingTick(deps), fireAndForget: true }
         case 'tab-track-ended':
-            return { fireAndForget: deps.stopRecording('tab-track-ended', true) }
+            return { response: deps.stopRecording('tab-track-ended', true), fireAndForget: true }
         case 'timer-expired':
-            return { fireAndForget: deps.stopRecording('timer', true) }
-        case 'pause-recording':
-            return { fireAndForget: deps.pauseRecording(message.trigger) }
-        case 'resume-recording':
-            return { fireAndForget: deps.resumeRecording(message.trigger) }
+            return { response: deps.stopRecording('timer', true), fireAndForget: true }
         case 'timer-updated':
-            const timerState = await deps.getRecordingState()
-            if (timerState.isRecording) {
-                const updatedTimerState = { ...timerState, stopAtMs: message.stopAtMs ?? undefined }
-                await deps.setRecordingState(updatedTimerState)
-                await deps.broadcastRecordingState()
-                await deps.updateActionTitle(updatedTimerState)
-            }
-            return {}
+            return { response: handleTimerUpdated(message, deps), fireAndForget: true }
         case 'confirm-timer-stop':
-            return { fireAndForget: deps.stopRecording(message.trigger, true) }
+            return { response: deps.stopRecording(message.trigger, true), fireAndForget: true }
         case 'unexpected-recording-state':
-            return { fireAndForget: deps.cancelRecording(message.error) }
+            return { response: deps.cancelRecording(message.error), fireAndForget: true }
         case 'save-config-sync':
-            await deps.storageSyncSet(Configuration.key, message.data)
-            return {}
+            return { response: handleSaveConfigSync(message, deps), fireAndForget: true }
         case 'fetch-config':
-            const defaultConfig = new Configuration()
-            const remoteConfig = await deps.getRemoteConfiguration()
-            if (remoteConfig == null) return {}
-            const config = deepMerge(defaultConfig, remoteConfig)
-            console.debug('fetch:', config)
-            return { response: config }
+            return { response: handleFetchConfig(deps), fireAndForget: false }
         case 'request-recording-state':
-            await deps.broadcastRecordingState()
-            return {}
+            return { response: handleRequestRecordingState(deps), fireAndForget: true }
     }
-    return {}
+    return null
+}
+
+async function handleResizeWindow(
+    message: Extract<Message, { type: 'resize-window' }>,
+    deps: ServiceWorkerDeps,
+): Promise<void> {
+    if (typeof message.data !== 'object' || message.data == null) return
+    await deps.resizeWindow(message.data)
+}
+
+async function handleRecordingTick(deps: ServiceWorkerDeps): Promise<void> {
+    const state = await deps.getRecordingState()
+    await deps.updateActionTitle(state)
+}
+
+async function handleTimerUpdated(
+    message: Extract<Message, { type: 'timer-updated' }>,
+    deps: ServiceWorkerDeps,
+): Promise<void> {
+    const timerState = await deps.getRecordingState()
+    if (timerState.isRecording) {
+        const updatedTimerState = { ...timerState, stopAtMs: message.stopAtMs ?? undefined }
+        await deps.setRecordingState(updatedTimerState)
+        await deps.broadcastRecordingState()
+        await deps.updateActionTitle(updatedTimerState)
+    }
+}
+
+async function handleSaveConfigSync(
+    message: Extract<Message, { type: 'save-config-sync' }>,
+    deps: ServiceWorkerDeps,
+): Promise<void> {
+    await deps.storageSyncSet(Configuration.key, message.data)
+}
+
+async function handleFetchConfig(deps: ServiceWorkerDeps): Promise<Configuration | void> {
+    const defaultConfig = new Configuration()
+    const remoteConfig = await deps.getRemoteConfiguration()
+    if (remoteConfig == null) return
+    const config = deepMerge(defaultConfig, remoteConfig)
+    console.debug('fetch:', config)
+    return config
+}
+
+async function handleRequestRecordingState(deps: ServiceWorkerDeps): Promise<void> {
+    await deps.broadcastRecordingState()
+}
+
+/**
+ * Creates the chrome.runtime.onMessage listener callback.
+ * Extracted for testability.
+ */
+export function createMessageListener(
+    deps: ServiceWorkerDeps,
+    onError: (e: unknown) => void,
+): (message: Message, sender: chrome.runtime.MessageSender, sendResponse: (response?: Configuration) => void) => boolean | undefined {
+    return (message, _sender, sendResponse) => {
+        const result = handleMessage(message, deps)
+        if (result == null) return
+
+        if (result.fireAndForget) {
+            result.response.catch(onError)
+            // NOTE: Must not return true or a truthy value to avoid blocking
+            // sendMessage callers waiting for responses from other contexts.
+            return
+        }
+
+        result.response.then(result => {
+            if (result != null) sendResponse(result)
+            else sendResponse()
+        }).catch(e => {
+            onError(e)
+            sendResponse()
+        })
+        return true // asynchronous flag
+    }
 }

--- a/tests/offscreen_handler.test.ts
+++ b/tests/offscreen_handler.test.ts
@@ -175,7 +175,7 @@ describe('start-recording', () => {
             data: { tabSize: { width: 1920, height: 1080 }, streamId: 'stream-1' },
             trigger: 'context-menu',
         })
-        expect(result!.response).toEqual(sessionResponse)
+        expect(result).toEqual(sessionResponse)
     })
 
     it('sets timer and adds stopAtMs when timer enabled', async () => {
@@ -192,8 +192,8 @@ describe('start-recording', () => {
                 data: { tabSize: { width: 1920, height: 1080 }, streamId: 'stream-1' },
                 trigger: 'action-icon',
             })
-            expect(result!.response?.stopAtMs).toBeDefined()
-            expect(typeof result!.response?.stopAtMs).toBe('number')
+            expect(result?.stopAtMs).toBeDefined()
+            expect(typeof result?.stopAtMs).toBe('number')
         } finally {
             vi.useRealTimers()
         }
@@ -211,7 +211,7 @@ describe('start-recording', () => {
             data: { tabSize: { width: 1920, height: 1080 }, streamId: 'stream-1' },
             trigger: 'action-icon',
         })
-        expect(result!.response?.stopAtMs).toBeUndefined()
+        expect(result?.stopAtMs).toBeUndefined()
     })
 
     it('does not set stopAtMs when durationMinutes is 0', async () => {
@@ -226,7 +226,7 @@ describe('start-recording', () => {
             data: { tabSize: { width: 1920, height: 1080 }, streamId: 'stream-1' },
             trigger: 'action-icon',
         })
-        expect(result!.response?.stopAtMs).toBeUndefined()
+        expect(result?.stopAtMs).toBeUndefined()
     })
 
     it('preserves all three trigger types', async () => {

--- a/tests/service_worker_handler.test.ts
+++ b/tests/service_worker_handler.test.ts
@@ -5,7 +5,7 @@ vi.mock('@mediabunny/flac-encoder', () => ({
     registerFlacEncoder: vi.fn(),
 }))
 
-import { handleMessage, type ServiceWorkerDeps } from '../src/service_worker_handler'
+import { handleMessage, createMessageListener, type ServiceWorkerDeps } from '../src/service_worker_handler'
 import type { Message } from '../src/message'
 import type { RecordingState } from '../src/handler'
 import type { Configuration } from '../src/configuration'
@@ -35,23 +35,23 @@ function createMockDeps(overrides: Partial<ServiceWorkerDeps> = {}): ServiceWork
 describe('confirm-timer-stop', () => {
     it('passes trigger to stopRecording with skipConfirmation=true', async () => {
         const deps = createMockDeps()
-        const result = await handleMessage({ type: 'confirm-timer-stop', trigger: 'keyboard-shortcut' }, deps)
-        expect(result.fireAndForget).toBeInstanceOf(Promise)
-        await result.fireAndForget
+        const result = handleMessage({ type: 'confirm-timer-stop', trigger: 'keyboard-shortcut' }, deps)
+        expect(result!.fireAndForget).toBe(true)
+        await result!.response
         expect(deps.stopRecording).toHaveBeenCalledWith('keyboard-shortcut', true)
     })
 
     it('preserves action-icon trigger', async () => {
         const deps = createMockDeps()
-        const result = await handleMessage({ type: 'confirm-timer-stop', trigger: 'action-icon' }, deps)
-        await result.fireAndForget
+        const result = handleMessage({ type: 'confirm-timer-stop', trigger: 'action-icon' }, deps)
+        await result!.response
         expect(deps.stopRecording).toHaveBeenCalledWith('action-icon', true)
     })
 
     it('preserves context-menu trigger', async () => {
         const deps = createMockDeps()
-        const result = await handleMessage({ type: 'confirm-timer-stop', trigger: 'context-menu' }, deps)
-        await result.fireAndForget
+        const result = handleMessage({ type: 'confirm-timer-stop', trigger: 'context-menu' }, deps)
+        await result!.response
         expect(deps.stopRecording).toHaveBeenCalledWith('context-menu', true)
     })
 })
@@ -61,9 +61,9 @@ describe('confirm-timer-stop', () => {
 describe('timer-expired', () => {
     it('calls stopRecording with timer trigger and skipConfirmation=true', async () => {
         const deps = createMockDeps()
-        const result = await handleMessage({ type: 'timer-expired' }, deps)
-        expect(result.fireAndForget).toBeInstanceOf(Promise)
-        await result.fireAndForget
+        const result = handleMessage({ type: 'timer-expired' }, deps)
+        expect(result!.fireAndForget).toBe(true)
+        await result!.response
         expect(deps.stopRecording).toHaveBeenCalledWith('timer', true)
     })
 })
@@ -76,7 +76,8 @@ describe('timer-updated', () => {
         const deps = createMockDeps({
             getRecordingState: vi.fn().mockResolvedValue(state),
         })
-        await handleMessage({ type: 'timer-updated', stopAtMs: 61000 }, deps)
+        const result = handleMessage({ type: 'timer-updated', stopAtMs: 61000 }, deps)
+        await result!.response
         expect(deps.setRecordingState).toHaveBeenCalledWith({ ...state, stopAtMs: 61000 })
         expect(deps.broadcastRecordingState).toHaveBeenCalled()
         expect(deps.updateActionTitle).toHaveBeenCalled()
@@ -87,7 +88,8 @@ describe('timer-updated', () => {
         const deps = createMockDeps({
             getRecordingState: vi.fn().mockResolvedValue(state),
         })
-        await handleMessage({ type: 'timer-updated', stopAtMs: null }, deps)
+        const result = handleMessage({ type: 'timer-updated', stopAtMs: null }, deps)
+        await result!.response
         expect(deps.setRecordingState).toHaveBeenCalledWith({ ...state, stopAtMs: undefined })
     })
 
@@ -95,7 +97,8 @@ describe('timer-updated', () => {
         const deps = createMockDeps({
             getRecordingState: vi.fn().mockResolvedValue({ isRecording: false }),
         })
-        await handleMessage({ type: 'timer-updated', stopAtMs: 61000 }, deps)
+        const result = handleMessage({ type: 'timer-updated', stopAtMs: 61000 }, deps)
+        await result!.response
         expect(deps.setRecordingState).not.toHaveBeenCalled()
         expect(deps.broadcastRecordingState).not.toHaveBeenCalled()
     })
@@ -106,9 +109,9 @@ describe('timer-updated', () => {
 describe('tab-track-ended', () => {
     it('calls stopRecording with tab-track-ended trigger and skipConfirmation=true (fire-and-forget)', async () => {
         const deps = createMockDeps()
-        const result = await handleMessage({ type: 'tab-track-ended' }, deps)
-        expect(result.fireAndForget).toBeInstanceOf(Promise)
-        await result.fireAndForget
+        const result = handleMessage({ type: 'tab-track-ended' }, deps)
+        expect(result!.fireAndForget).toBe(true)
+        await result!.response
         expect(deps.stopRecording).toHaveBeenCalledWith('tab-track-ended', true)
     })
 })
@@ -118,9 +121,9 @@ describe('tab-track-ended', () => {
 describe('unexpected-recording-state', () => {
     it('calls cancelRecording with error (fire-and-forget)', async () => {
         const deps = createMockDeps()
-        const result = await handleMessage({ type: 'unexpected-recording-state', error: 'test error' }, deps)
-        expect(result.fireAndForget).toBeInstanceOf(Promise)
-        await result.fireAndForget
+        const result = handleMessage({ type: 'unexpected-recording-state', error: 'test error' }, deps)
+        expect(result!.fireAndForget).toBe(true)
+        await result!.response
         expect(deps.cancelRecording).toHaveBeenCalledWith('test error')
     })
 })
@@ -133,7 +136,8 @@ describe('recording-tick', () => {
         const deps = createMockDeps({
             getRecordingState: vi.fn().mockResolvedValue(state),
         })
-        await handleMessage({ type: 'recording-tick' }, deps)
+        const result = handleMessage({ type: 'recording-tick' }, deps)
+        await result!.response
         expect(deps.updateActionTitle).toHaveBeenCalledWith(state)
     })
 })
@@ -143,13 +147,15 @@ describe('recording-tick', () => {
 describe('resize-window', () => {
     it('calls resizeWindow with data', async () => {
         const deps = createMockDeps()
-        await handleMessage({ type: 'resize-window', data: { width: 1280, height: 720 } }, deps)
+        const result = handleMessage({ type: 'resize-window', data: { width: 1280, height: 720 } }, deps)
+        await result!.response
         expect(deps.resizeWindow).toHaveBeenCalledWith({ width: 1280, height: 720 })
     })
 
     it('ignores invalid data (null)', async () => {
         const deps = createMockDeps()
-        await handleMessage({ type: 'resize-window', data: null as unknown as { width: number; height: number } }, deps)
+        const result = handleMessage({ type: 'resize-window', data: null as unknown as { width: number; height: number } }, deps)
+        await result!.response
         expect(deps.resizeWindow).not.toHaveBeenCalled()
     })
 })
@@ -160,7 +166,8 @@ describe('save-config-sync', () => {
     it('saves config to sync storage', async () => {
         const deps = createMockDeps()
         const syncData = { key: 'value' } as unknown as Configuration
-        await handleMessage({ type: 'save-config-sync', data: syncData } as Message, deps)
+        const result = handleMessage({ type: 'save-config-sync', data: syncData } as Message, deps)
+        await result!.response
         expect(deps.storageSyncSet).toHaveBeenCalledWith('settings', syncData)
     })
 })
@@ -173,17 +180,19 @@ describe('fetch-config', () => {
         const deps = createMockDeps({
             getRemoteConfiguration: vi.fn().mockResolvedValue(remoteConfig),
         })
-        const result = await handleMessage({ type: 'fetch-config' }, deps)
-        expect(result.response).toBeDefined()
-        expect(result.response?.userId).toBe('test-user')
+        const result = handleMessage({ type: 'fetch-config' }, deps)
+        const config = await result!.response
+        expect(config).toBeDefined()
+        expect(config?.userId).toBe('test-user')
     })
 
-    it('returns empty result when no remote config', async () => {
+    it('returns undefined when no remote config', async () => {
         const deps = createMockDeps({
             getRemoteConfiguration: vi.fn().mockResolvedValue(null),
         })
-        const result = await handleMessage({ type: 'fetch-config' }, deps)
-        expect(result.response).toBeUndefined()
+        const result = handleMessage({ type: 'fetch-config' }, deps)
+        const config = await result!.response
+        expect(config).toBeUndefined()
     })
 })
 
@@ -192,7 +201,8 @@ describe('fetch-config', () => {
 describe('request-recording-state', () => {
     it('broadcasts recording state', async () => {
         const deps = createMockDeps()
-        await handleMessage({ type: 'request-recording-state' }, deps)
+        const result = handleMessage({ type: 'request-recording-state' }, deps)
+        await result!.response
         expect(deps.broadcastRecordingState).toHaveBeenCalled()
     })
 })
@@ -200,47 +210,103 @@ describe('request-recording-state', () => {
 // ---------- unknown message types ----------
 
 describe('unknown message type', () => {
-    it('returns empty result for unhandled message types', async () => {
+    it('returns null for unhandled message types', () => {
         const deps = createMockDeps()
-        const result = await handleMessage({ type: 'start-recording' } as unknown as Message, deps)
-        expect(result).toEqual({})
+        const result = handleMessage({ type: 'start-recording' } as unknown as Message, deps)
+        expect(result).toBeNull()
     })
 })
 
-// ---------- pause-recording ----------
+// ---------- createMessageListener ----------
 
-describe('pause-recording', () => {
-    it('calls pauseRecording via fireAndForget', async () => {
+describe('createMessageListener', () => {
+    const dummySender = {} as chrome.runtime.MessageSender
+
+    it('returns undefined for unhandled messages (does not block sender)', () => {
         const deps = createMockDeps()
-        const result = await handleMessage({ type: 'pause-recording', trigger: 'keyboard-shortcut' }, deps)
-        expect(result.fireAndForget).toBeInstanceOf(Promise)
-        await result.fireAndForget
-        expect(deps.pauseRecording).toHaveBeenCalledWith('keyboard-shortcut')
+        const onError = vi.fn()
+        const listener = createMessageListener(deps, onError)
+
+        const sendResponse = vi.fn()
+        const ret = listener({ type: 'start-recording' } as unknown as Message, dummySender, sendResponse)
+
+        expect(ret).toBeUndefined()
+        expect(sendResponse).not.toHaveBeenCalled()
     })
 
-    it('preserves context-menu trigger', async () => {
+    it('returns undefined for fireAndForget messages (does not block sender)', () => {
         const deps = createMockDeps()
-        const result = await handleMessage({ type: 'pause-recording', trigger: 'context-menu' }, deps)
-        await result.fireAndForget
-        expect(deps.pauseRecording).toHaveBeenCalledWith('context-menu')
-    })
-})
+        const onError = vi.fn()
+        const listener = createMessageListener(deps, onError)
 
-// ---------- resume-recording ----------
+        const sendResponse = vi.fn()
+        const ret = listener({ type: 'recording-tick' } as Message, dummySender, sendResponse)
 
-describe('resume-recording', () => {
-    it('calls resumeRecording via fireAndForget', async () => {
-        const deps = createMockDeps()
-        const result = await handleMessage({ type: 'resume-recording', trigger: 'keyboard-shortcut' }, deps)
-        expect(result.fireAndForget).toBeInstanceOf(Promise)
-        await result.fireAndForget
-        expect(deps.resumeRecording).toHaveBeenCalledWith('keyboard-shortcut')
+        expect(ret).toBeUndefined()
+        expect(sendResponse).not.toHaveBeenCalled()
     })
 
-    it('preserves context-menu trigger', async () => {
+    it('returns true for response messages (keeps channel open)', () => {
         const deps = createMockDeps()
-        const result = await handleMessage({ type: 'resume-recording', trigger: 'context-menu' }, deps)
-        await result.fireAndForget
-        expect(deps.resumeRecording).toHaveBeenCalledWith('context-menu')
+        const onError = vi.fn()
+        const listener = createMessageListener(deps, onError)
+
+        const sendResponse = vi.fn()
+        const ret = listener({ type: 'fetch-config' } as Message, dummySender, sendResponse)
+
+        expect(ret).toBe(true)
+    })
+
+    it('calls sendResponse with config when response resolves', async () => {
+        const remoteConfig = { userId: 'test' } as Configuration
+        const deps = createMockDeps({
+            getRemoteConfiguration: vi.fn().mockResolvedValue(remoteConfig),
+        })
+        const onError = vi.fn()
+        const listener = createMessageListener(deps, onError)
+
+        const sendResponse = vi.fn()
+        listener({ type: 'fetch-config' } as Message, dummySender, sendResponse)
+
+        await vi.waitFor(() => {
+            expect(sendResponse).toHaveBeenCalledTimes(1)
+        })
+        expect(sendResponse).toHaveBeenCalledWith(expect.objectContaining({ userId: 'test' }))
+        expect(onError).not.toHaveBeenCalled()
+    })
+
+    it('calls sendResponse once and onError when response rejects', async () => {
+        const error = new Error('fetch failed')
+        const deps = createMockDeps({
+            getRemoteConfiguration: vi.fn().mockRejectedValue(error),
+        })
+        const onError = vi.fn()
+        const listener = createMessageListener(deps, onError)
+
+        const sendResponse = vi.fn()
+        listener({ type: 'fetch-config' } as Message, dummySender, sendResponse)
+
+        await vi.waitFor(() => {
+            expect(sendResponse).toHaveBeenCalledTimes(1)
+        })
+        expect(sendResponse).toHaveBeenCalledWith()
+        expect(onError).toHaveBeenCalledWith(error)
+    })
+
+    it('calls onError when fireAndForget rejects', async () => {
+        const error = new Error('tick failed')
+        const deps = createMockDeps({
+            getRecordingState: vi.fn().mockRejectedValue(error),
+        })
+        const onError = vi.fn()
+        const listener = createMessageListener(deps, onError)
+
+        const sendResponse = vi.fn()
+        listener({ type: 'recording-tick' } as Message, dummySender, sendResponse)
+
+        await vi.waitFor(() => {
+            expect(onError).toHaveBeenCalledWith(error)
+        })
+        expect(sendResponse).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
- fix #550 

This pull request refactors how message handling and responses are managed across several components, primarily to ensure that asynchronous message handlers do not inadvertently interfere with other message contexts by returning truthy values or Promises. It also simplifies and standardizes the message handling API, removes unnecessary wrapper types, and improves error handling and testability.

**Refactoring and Standardization of Message Handling:**

* Message handlers in `Cropping`, `CroppingPreview`, and `RecordList` components are now synchronous and do not return Promises or truthy values, preventing interference with other message contexts. Asynchronous work is now done inside immediately-invoked async functions with proper error logging. [[1]](diffhunk://#diff-81dabb420a898a953e6bf91f030fd1ed06c8c37f5e7c4f4d81062a8671fe66a3R94-R98) [[2]](diffhunk://#diff-701fd87d451b3ceea98b26bf1e7a19e57d4ad6ef2305135de6b1063291885bc5L165-R169) [[3]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L162-R166)
* The `offscreen_handler.ts` API is simplified: the custom `HandleOffscreenMessageResult` wrapper type is removed, and handlers now return either the direct response or `void`. [[1]](diffhunk://#diff-2cd9574db7de00aeee9efe2ae07c8b53c29c954d46d5b9078efe3388cf8afaebL43-L48) [[2]](diffhunk://#diff-2cd9574db7de00aeee9efe2ae07c8b53c29c954d46d5b9078efe3388cf8afaebL58-R52) [[3]](diffhunk://#diff-2cd9574db7de00aeee9efe2ae07c8b53c29c954d46d5b9078efe3388cf8afaebL87-R81) [[4]](diffhunk://#diff-2cd9574db7de00aeee9efe2ae07c8b53c29c954d46d5b9078efe3388cf8afaebL118-R115) [[5]](diffhunk://#diff-2cd9574db7de00aeee9efe2ae07c8b53c29c954d46d5b9078efe3388cf8afaebL144-R140) [[6]](diffhunk://#diff-2cd9574db7de00aeee9efe2ae07c8b53c29c954d46d5b9078efe3388cf8afaebL166-L212)

**Service Worker Message Handling Improvements:**

* The service worker now uses a new `createMessageListener` utility, which standardizes error handling and ensures correct response semantics for fire-and-forget and response-returning messages. The previous `handleMessage` function is refactored for clarity and testability. [[1]](diffhunk://#diff-9a8dfe07c2bfeb25a7bcb4e293c44857c0bbbfc3417c31f1dc9d1d3482864216L25-R24) [[2]](diffhunk://#diff-9a8dfe07c2bfeb25a7bcb4e293c44857c0bbbfc3417c31f1dc9d1d3482864216L422-R428) [[3]](diffhunk://#diff-3387c9a641bb064c8f2a7ab711fd42c52a69d02fe3ca71c99dd0a238b44e5bedL25-R131)
* The service worker message handler's result type is updated to clearly distinguish between response and fire-and-forget messages, and to avoid returning Promises from fire-and-forget handlers.

**Bug Fixes and Behavior Changes:**

* The message listener in `offscreen.ts` now sends the correct response object, fixing a potential bug where the wrong property was returned.

**Test Updates:**

* Tests are updated to reflect the new handler return values, removing references to the obsolete `.response` property. [[1]](diffhunk://#diff-430b24f1c6b6b7cd707bc3427ed61d67bac46459739d4e5151415537d59a84d4L178-R178) [[2]](diffhunk://#diff-430b24f1c6b6b7cd707bc3427ed61d67bac46459739d4e5151415537d59a84d4L195-R196) [[3]](diffhunk://#diff-430b24f1c6b6b7cd707bc3427ed61d67bac46459739d4e5151415537d59a84d4L214-R214) [[4]](diffhunk://#diff-430b24f1c6b6b7cd707bc3427ed61d67bac46459739d4e5151415537d59a84d4L229-R229)
* Test imports are updated to use the new `createMessageListener` for improved testability.