### PR TITLE
bump: v1.6.1

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
     "name": "Instant Tab Recorder",
     "short_name": "Tab Recorder",
     "description": "Blazingly simple tab recorder.",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "minimum_chrome_version": "140",
     "icons": {
         "16": "icons/icon16.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instant-tab-recorder",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instant-tab-recorder",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@material/web": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instant-tab-recorder",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "description": "Google Chrome Extensions Screen Recorder",
   "scripts": {


### PR DESCRIPTION
This pull request updates the version number of the Instant Tab Recorder extension from 1.6.0 to 1.6.1 in both the Chrome extension manifest and the `package.json` file. No other changes are included.

- Version bump:
  * Updated the `version` field in `extension/manifest.json` from 1.6.0 to 1.6.1.
  * Updated the `version` field in `package.json` from 1.6.0 to 1.6.1.