### PR TITLE
fix: fix recording state display on RecordList

### DIFF
--- a/src/element/recordList.ts
+++ b/src/element/recordList.ts
@@ -17,7 +17,7 @@ import { MdFilterChip } from '@material/web/chips/filter-chip'
 import Confirm from './confirm'
 import Alert from './alert'
 import type { ShowDirectoryPickerOptions } from '../type'
-import { Message, SaveConfigSyncMessage } from '../message'
+import { Message, SaveConfigSyncMessage, RequestRecordingStateMessage } from '../message'
 import { sendException } from '../sentry'
 import { recordingApi } from '../api_client'
 import type { StorageEstimateInfo } from '../storage'
@@ -92,6 +92,20 @@ export class RecordList extends LitElement {
         .recording {
             color: var(--theme-recording, #d93025);
         }
+        .elapsed-time {
+            margin-left: 0.25em;
+        }
+        .elapsed-blink {
+            animation: blink 1s step-end infinite;
+        }
+        @keyframes blink {
+            50% { visibility: hidden; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .elapsed-blink {
+                animation: none;
+            }
+        }
         .sub-file-icon {
             color: var(--theme-text-secondary, #3f4948);
             margin-left: 4px;
@@ -140,17 +154,20 @@ export class RecordList extends LitElement {
     }
 
     override connectedCallback() {
-        super.connectedCallback();
+        super.connectedCallback()
+        chrome.runtime.onMessage.addListener(this.handleMessage);
         (async () => {
             await this.updateRecord()
             this.syncElapsedTimer()
             await this.updateEstimate()
             await this.checkStoredRecordingError()
+            // Request current recording state to get accurate pause info
+            const msg: RequestRecordingStateMessage = { type: 'request-recording-state' }
+            await chrome.runtime.sendMessage(msg)
         })().catch(e => {
             console.error(e)
             sendException(e, { exceptionSource: 'option.recordList.connectedCallback' })
         })
-        chrome.runtime.onMessage.addListener(this.handleMessage)
     }
 
     override disconnectedCallback() {
@@ -229,7 +246,7 @@ export class RecordList extends LitElement {
                     })}
                 <div class="meta" title="file size"><md-icon>storage</md-icon> ${formatNum((record.size + record.subFilesSize) / 1024 / 1024, 2)} MB ${record.subFilesSize > 0 ? html` <span title="separated audio file size">(${formatNum(record.subFilesSize / 1024 / 1024, 2)} MB separated)</span>` : ''}</div>
                 ${record.recordedAt != null ? html`<div class="meta" title="recorded at"><md-icon>schedule</md-icon> ${RecordList.dateTimeFormat.format(record.recordedAt)}</div>` : ''}
-                ${record.isRecording ? html`<div class="meta recording" title="recording"><md-icon>screen_record</md-icon> ${this.recordingPaused ? 'Paused' : 'Recording'} ${this.elapsedTimeText}${this.timerStopText ? html` <span title="timer stop time">(⏱ ${this.recordingPaused ? 'timer paused' : `stops at ${this.timerStopText}`})</span>` : ''}</div>` : ''}
+                ${record.isRecording ? html`<div class="meta recording" title="recording"><md-icon>screen_record</md-icon> ${this.recordingPaused ? 'Paused' : 'Recording'} <span class="elapsed-time${this.recordingPaused ? ' elapsed-blink' : ''}">${this.elapsedTimeText}</span>${this.timerStopText ? html` <span title="timer stop time">(⏱ ${this.recordingPaused ? 'timer paused' : `stops at ${this.timerStopText}`})</span>` : ''}</div>` : ''}
                 <md-filled-icon-button slot="end" ?disabled=${record.isRecording} @click=${this.playRecord(record)}>
                     <md-icon>play_arrow</md-icon>
                 </md-filled-icon-button>

--- a/tests/element/recordList.test.ts
+++ b/tests/element/recordList.test.ts
@@ -1,14 +1,16 @@
 import { render } from 'vitest-browser-lit'
 import { html } from 'lit'
-import { describe, test, expect, vi } from 'vitest'
+import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { shadowQuery, elementUpdated } from './test-helpers'
-import { getMessageListenersCount } from './test-setup'
+import { getChromeMock, getMessageListenersCount, simulateChromeMessage } from './test-setup'
 import '../../src/element/recordList'
+import type { RecordingMetadata } from '../../src/storage'
 
 // Mock the api_client module used by RecordList
+const listRecordingsMock = vi.fn().mockResolvedValue([])
 vi.mock('../../src/api_client', () => ({
     recordingApi: {
-        listRecordings: vi.fn().mockResolvedValue([]),
+        listRecordings: (...args: unknown[]) => listRecordingsMock(...args),
         getRecordingFile: vi.fn().mockResolvedValue(null),
         deleteRecording: vi.fn().mockResolvedValue(undefined),
         getStorageEstimate: vi.fn().mockResolvedValue({ usage: 0, quota: 1073741824 }),
@@ -23,6 +25,10 @@ vi.mock('../../src/sentry', () => ({
 }))
 
 describe('record-list', () => {
+    beforeEach(() => {
+        listRecordingsMock.mockReset().mockResolvedValue([])
+    })
+
     test('renders storage heading', async () => {
         const screen = render(html`<record-list></record-list>`)
         const el = screen.container.querySelector('record-list')!
@@ -131,5 +137,149 @@ describe('record-list', () => {
         const heading = shadowQuery(el, '.storage-heading')
         expect(heading?.textContent).toContain('total:')
         expect(heading?.textContent).toContain('MB')
+    })
+
+    test('connectedCallback sends request-recording-state message', async () => {
+        const chromeMock = getChromeMock()
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            expect(chromeMock.runtime.sendMessage).toHaveBeenCalledWith(
+                expect.objectContaining({ type: 'request-recording-state' }),
+            )
+        })
+    })
+
+    test('shows paused state with elapsed-blink class on recording-state message', async () => {
+        const startAtMs = Date.now() - 5000
+        const recordingMeta: RecordingMetadata = {
+            title: 'video-' + startAtMs + '.webm',
+            size: 1024,
+            lastModified: Date.now(),
+            mimeType: 'video/webm',
+            recordedAt: startAtMs,
+            isRecording: true,
+            isTemporary: true,
+        }
+        listRecordingsMock.mockResolvedValue([recordingMeta])
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        // Simulate a paused recording-state message
+        simulateChromeMessage({
+            type: 'recording-state',
+            data: {
+                isRecording: true,
+                isPaused: true,
+                totalPausedMs: 2000,
+                startAtMs,
+            },
+        })
+
+        await vi.waitFor(() => {
+            const recordingDiv = shadowQuery(el, '.recording')
+            expect(recordingDiv).not.toBeNull()
+            expect(recordingDiv?.textContent).toContain('Paused')
+            const blinkSpan = shadowQuery(el, '.elapsed-blink')
+            expect(blinkSpan).not.toBeNull()
+            expect(blinkSpan?.classList.contains('elapsed-time')).toBe(true)
+        })
+    })
+
+    test('shows recording state without elapsed-blink class when not paused', async () => {
+        const startAtMs = Date.now() - 5000
+        const recordingMeta: RecordingMetadata = {
+            title: 'video-' + startAtMs + '.webm',
+            size: 1024,
+            lastModified: Date.now(),
+            mimeType: 'video/webm',
+            recordedAt: startAtMs,
+            isRecording: true,
+            isTemporary: true,
+        }
+        listRecordingsMock.mockResolvedValue([recordingMeta])
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        // Simulate a non-paused recording-state message
+        simulateChromeMessage({
+            type: 'recording-state',
+            data: {
+                isRecording: true,
+                isPaused: false,
+                totalPausedMs: 0,
+                startAtMs,
+            },
+        })
+
+        await vi.waitFor(() => {
+            const recordingDiv = shadowQuery(el, '.recording')
+            expect(recordingDiv).not.toBeNull()
+            expect(recordingDiv?.textContent).toContain('Recording')
+            const elapsedSpan = shadowQuery(el, '.elapsed-time')
+            expect(elapsedSpan).not.toBeNull()
+            expect(elapsedSpan?.classList.contains('elapsed-blink')).toBe(false)
+        })
+    })
+
+    test('elapsed time stops updating while paused', async () => {
+        vi.useFakeTimers()
+        try {
+            const startAtMs = Date.now() - 10000
+            const recordingMeta: RecordingMetadata = {
+                title: 'video-' + startAtMs + '.webm',
+                size: 1024,
+                lastModified: Date.now(),
+                mimeType: 'video/webm',
+                recordedAt: startAtMs,
+                isRecording: true,
+                isTemporary: true,
+            }
+            listRecordingsMock.mockResolvedValue([recordingMeta])
+
+            const screen = render(html`<record-list></record-list>`)
+            const el = screen.container.querySelector('record-list')!
+            await elementUpdated(el)
+
+            // Flush pending microtasks from connectedCallback
+            await vi.advanceTimersByTimeAsync(0)
+
+            // Simulate a paused recording-state with known totalPausedMs
+            const totalPausedMs = 3000
+            simulateChromeMessage({
+                type: 'recording-state',
+                data: {
+                    isRecording: true,
+                    isPaused: true,
+                    totalPausedMs,
+                    startAtMs,
+                },
+            })
+
+            // Flush microtasks so the message handler and re-render complete
+            await vi.advanceTimersByTimeAsync(0)
+            await elementUpdated(el)
+
+            const elapsedSpan = shadowQuery(el, '.elapsed-time')
+            expect(elapsedSpan).not.toBeNull()
+
+            // Capture the frozen elapsed text
+            const frozenText = elapsedSpan!.textContent
+
+            // Advance time well past the 1-second update interval
+            await vi.advanceTimersByTimeAsync(3000)
+            await elementUpdated(el)
+
+            // Verify it hasn't changed (timer is stopped during pause)
+            expect(elapsedSpan!.textContent).toBe(frozenText)
+        } finally {
+            vi.useRealTimers()
+        }
     })
 })


### PR DESCRIPTION
This pull request enhances the recording UI in `recordList.ts` by improving the display of elapsed recording time and ensuring accurate recording state information. The main changes focus on visual feedback for users and synchronizing the UI with the actual recording state.

**UI Improvements:**
* The elapsed recording time now appears in its own styled span (`.elapsed-time`), and when recording is paused, it blinks to provide clear visual feedback. [[1]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3R95-R103) [[2]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L232-R244)

**State Synchronization:**
* On component connection, the UI now explicitly requests the current recording state from the background script to ensure accurate pause/resume information is shown. [[1]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L20-R20) [[2]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3R158-R160)