### PR TITLE
fix: enhance audio separation to support audio-only mode with mic

### DIFF
--- a/src/recorder/audio_separation.ts
+++ b/src/recorder/audio_separation.ts
@@ -29,7 +29,7 @@ export class AudioSeparationManager {
         startAtMs: number,
         tabMedia: MediaStream,
         micStream: MediaStream | null,
-        videoFormat: VideoFormat,
+        { recordingMode, audioCodec, audioBitratePreset, audioBitrate }: VideoFormat,
     ): Promise<AudioSeparationOutputs> {
         const result: AudioSeparationOutputs = {
             sources: [],
@@ -37,11 +37,11 @@ export class AudioSeparationManager {
             errorPromises: [],
         }
 
-        const sepContainer = audioSeparationContainer(videoFormat.audioCodec)
+        const sepContainer = audioSeparationContainer(audioCodec)
         const sepExt = containerExtension(sepContainer)
 
-        // Tab audio separation: only when recordingMode is video-and-audio
-        if (videoFormat.recordingMode === 'video-and-audio') {
+        // Tab audio separation: when recordingMode is video-and-audio or audio-only with mic
+        if (recordingMode === 'video-and-audio' || (recordingMode === 'audio-only' && micStream)) {
             const tabAudioTrack = tabMedia.getAudioTracks()[0]?.clone() as MediaStreamAudioTrack | undefined
             if (tabAudioTrack) {
                 const tabFileName = Configuration.audioFilename(startAtMs, 'tab', sepExt)
@@ -51,9 +51,9 @@ export class AudioSeparationManager {
                     writableStream,
                     tabAudioTrack,
                     sepContainer,
-                    videoFormat.audioCodec,
-                    videoFormat.audioBitratePreset,
-                    videoFormat.audioBitrate,
+                    audioCodec,
+                    audioBitratePreset,
+                    audioBitrate,
                 )
                 result.tabOutput = handle.output
                 result.sources.push(...handle.sources)
@@ -73,9 +73,9 @@ export class AudioSeparationManager {
                     writableStream,
                     micAudioTrack,
                     sepContainer,
-                    videoFormat.audioCodec,
-                    videoFormat.audioBitratePreset,
-                    videoFormat.audioBitrate,
+                    audioCodec,
+                    audioBitratePreset,
+                    audioBitrate,
                 )
                 result.micOutput = handle.output
                 result.sources.push(...handle.sources)

--- a/tests/recorder/audio_separation.test.ts
+++ b/tests/recorder/audio_separation.test.ts
@@ -118,6 +118,41 @@ describe('AudioSeparationManager', () => {
             expect(fileMgr.createAudioFile).toHaveBeenCalledWith('video-2000-tab.aac')
         })
 
+        test('creates tab + mic outputs when audio-only mode with mic', async () => {
+            const fileMgr = createMockFileManager()
+            const outMgr = createMockOutputManager()
+            const mgr = new AudioSeparationManager(fileMgr, outMgr)
+
+            const tabMedia = createMockStream([createMockTrack('audio', 'tab')])
+            const micStream = createMockStream([createMockTrack('audio', 'mic')])
+            const vf = createVideoFormat({ recordingMode: 'audio-only', audioCodec: 'opus' })
+
+            const result = await mgr.createOutputs(1500, tabMedia, micStream, vf)
+
+            expect(result.tabOutput).toBeDefined()
+            expect(result.micOutput).toBeDefined()
+            expect(result.clonedTracks).toHaveLength(2)
+            expect(fileMgr.createAudioFile).toHaveBeenCalledTimes(2)
+            expect(fileMgr.createAudioFile).toHaveBeenCalledWith('video-1500-tab.ogg')
+            expect(fileMgr.createAudioFile).toHaveBeenCalledWith('video-1500-mic.ogg')
+        })
+
+        test('creates no outputs when audio-only mode without mic', async () => {
+            const fileMgr = createMockFileManager()
+            const outMgr = createMockOutputManager()
+            const mgr = new AudioSeparationManager(fileMgr, outMgr)
+
+            const tabMedia = createMockStream([createMockTrack('audio', 'tab')])
+            const vf = createVideoFormat({ recordingMode: 'audio-only', audioCodec: 'opus' })
+
+            const result = await mgr.createOutputs(1600, tabMedia, null, vf)
+
+            expect(result.tabOutput).toBeUndefined()
+            expect(result.micOutput).toBeUndefined()
+            expect(result.clonedTracks).toHaveLength(0)
+            expect(fileMgr.createAudioFile).not.toHaveBeenCalled()
+        })
+
         test('creates only mic output when video-only mode with mic', async () => {
             const fileMgr = createMockFileManager()
             const outMgr = createMockOutputManager()


### PR DESCRIPTION
- fix #587

This pull request updates the audio separation logic to better handle the "audio-only" recording mode and improves test coverage for these scenarios. The main changes include adjusting when tab and mic audio outputs are created and ensuring the correct parameters are passed throughout the code.

**Audio separation logic improvements:**

* Updated the logic in `AudioSeparationManager.createOutputs` to create tab and mic outputs when in "audio-only" mode with a mic stream, in addition to the existing "video-and-audio" mode. No outputs are created for "audio-only" mode without a mic.

**Parameter handling:**

* Refactored `AudioSeparationManager.createOutputs` and related calls to destructure the `VideoFormat` object, passing only the necessary audio parameters (`audioCodec`, `audioBitratePreset`, `audioBitrate`) instead of the entire object. [[1]](diffhunk://#diff-3c50ee269ce372f2e5250fd4ff8584c8c3cdcac8f3ef95e47a67fa95117d6c48L32-R44) [[2]](diffhunk://#diff-3c50ee269ce372f2e5250fd4ff8584c8c3cdcac8f3ef95e47a67fa95117d6c48L54-R56) [[3]](diffhunk://#diff-3c50ee269ce372f2e5250fd4ff8584c8c3cdcac8f3ef95e47a67fa95117d6c48L76-R78)

**Test coverage:**

* Added tests to verify that tab and mic outputs are created when in "audio-only" mode with a mic, and that no outputs are created when in "audio-only" mode without a mic stream.