### PR TITLE
fix: update storage heading to show total size in MB only

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -438,16 +438,12 @@
         "description": "Button to restore default settings"
     },
     "recordListStorage": {
-        "message": "Storage (total: $SIZE$ MB, $PERCENT$)",
+        "message": "Storage (total: $SIZE$ MB)",
         "description": "Storage heading with usage info",
         "placeholders": {
             "size": {
                 "content": "$1",
                 "example": "150.5"
-            },
-            "percent": {
-                "content": "$2",
-                "example": "12.3%"
             }
         }
     },

--- a/extension/_locales/ja/messages.json
+++ b/extension/_locales/ja/messages.json
@@ -333,13 +333,10 @@
         "message": "デフォルト設定に戻す"
     },
     "recordListStorage": {
-        "message": "ストレージ (合計: $SIZE$ MB, $PERCENT$)",
+        "message": "ストレージ (合計: $SIZE$ MB)",
         "placeholders": {
             "size": {
                 "content": "$1"
-            },
-            "percent": {
-                "content": "$2"
             }
         }
     },

--- a/src/element/recordList.ts
+++ b/src/element/recordList.ts
@@ -1,7 +1,7 @@
 import { html, css, LitElement } from 'lit'
 import { customElement, property, state } from 'lit/decorators.js'
 import { repeat } from 'lit/directives/repeat.js'
-import { formatNum, formatRate, checkFileHandlePermission } from './util'
+import { formatNum, checkFileHandlePermission } from './util'
 import '@material/web/list/list'
 import '@material/web/list/list-item'
 import '@material/web/divider/divider'
@@ -20,7 +20,6 @@ import type { ShowDirectoryPickerOptions } from '../type'
 import { Message, SaveConfigSyncMessage, RequestRecordingStateMessage } from '../message'
 import { sendException } from '../sentry'
 import { recordingApi } from '../api_client'
-import type { StorageEstimateInfo } from '../storage'
 import { Settings } from './settings'
 import { Configuration, RecordingSortOrder } from '../configuration'
 import { formatElapsedTime } from '../format'
@@ -131,9 +130,6 @@ export class RecordList extends LitElement {
         second: '2-digit',
     })
 
-    @property({ noAccessor: true })
-    private estimate: StorageEstimateInfo
-
     @property({ type: Array })
     private records: Array<RecordEntry>
 
@@ -154,7 +150,6 @@ export class RecordList extends LitElement {
 
     public constructor() {
         super()
-        this.estimate = { usage: 0, quota: 0 }
         this.records = []
         this.sortOrder = Settings.getConfiguration().recordingSortOrder
     }
@@ -165,7 +160,6 @@ export class RecordList extends LitElement {
         ;(async () => {
             await this.updateRecord()
             this.syncElapsedTimer()
-            await this.updateEstimate()
             await this.checkStoredRecordingError()
             // Request current recording state to get accurate pause info
             const msg: RequestRecordingStateMessage = { type: 'request-recording-state' }
@@ -203,7 +197,6 @@ export class RecordList extends LitElement {
                 this.stopElapsedTimer()
             }
             await this.updateRecord()
-            await this.updateEstimate()
             await this.checkStoredRecordingError()
         })().catch(e => {
             console.error(e)
@@ -300,14 +293,10 @@ export class RecordList extends LitElement {
                     </md-filled-icon-button>
                 </md-list-item>`
         }
-        const est = this.estimate
-        const usage = est.usage
-        const quota = est.quota || 1
+        const totalSize = this.records.reduce((sum, r) => sum + r.size + r.subFilesSize, 0)
         const sortIcon = this.sortOrder === 'asc' ? 'arrow_upward' : 'arrow_downward'
         const sortLabel = this.sortOrder === 'asc' ? t('recordListSortAsc') : t('recordListSortDesc')
-        return html` <h2 class="storage-heading">
-                ${t('recordListStorage', [formatNum(usage / 1024 / 1024, 1), formatRate(usage / quota, 1)])}
-            </h2>
+        return html` <h2 class="storage-heading">${t('recordListStorage', [formatNum(totalSize / 1024 / 1024, 1)])}</h2>
             <md-chip-set class="selected-actions">
                 <md-filter-chip
                     label=${t('recordListSelectAll')}
@@ -383,11 +372,6 @@ export class RecordList extends LitElement {
         const oldVal = [...this.records]
         this.records = result
         this.requestUpdate('records', oldVal)
-    }
-    private async updateEstimate() {
-        const oldVal = this.estimate
-        this.estimate = await recordingApi.getStorageEstimate()
-        this.requestUpdate('estimate', oldVal)
     }
 
     private syncElapsedTimer() {
@@ -570,9 +554,6 @@ export class RecordList extends LitElement {
                             this.removeRecord(record)
                         }),
                     )
-
-                    // update UI
-                    this.updateEstimate()
                 } catch (e) {
                     sendException(e, { exceptionSource: 'option.recordList.delete.dialog' })
                 }

--- a/tests/element/recordList.test.ts
+++ b/tests/element/recordList.test.ts
@@ -129,7 +129,7 @@ describe('record-list', () => {
         expect(chipSet).not.toBeNull()
     })
 
-    test('storage heading includes total and percentage', async () => {
+    test('storage heading includes total and MB', async () => {
         const screen = render(html`<record-list></record-list>`)
         const el = screen.container.querySelector('record-list')!
         await elementUpdated(el)
@@ -137,6 +137,51 @@ describe('record-list', () => {
         const heading = shadowQuery(el, '.storage-heading')
         expect(heading?.textContent).toContain('total:')
         expect(heading?.textContent).toContain('MB')
+        expect(heading?.textContent).not.toContain('%')
+    })
+
+    test('storage heading shows sum of record sizes including subFilesSize', async () => {
+        const ts1 = '1000000000000'
+        const ts2 = '1000000001000'
+        const recordings: RecordingMetadata[] = [
+            {
+                title: `video-${ts1}.webm`,
+                size: 5 * 1024 * 1024, // 5 MB
+                lastModified: Date.now(),
+                mimeType: 'video/webm',
+                recordedAt: Number(ts1),
+                isTemporary: false,
+            },
+            {
+                title: `video-${ts1}-tab.ogg`,
+                size: 1 * 1024 * 1024, // 1 MB (sub-file)
+                lastModified: Date.now(),
+                mimeType: 'audio/ogg',
+                recordedAt: Number(ts1),
+                isTemporary: false,
+            },
+            {
+                title: `video-${ts2}.webm`,
+                size: 3 * 1024 * 1024, // 3 MB
+                lastModified: Date.now(),
+                mimeType: 'video/webm',
+                recordedAt: Number(ts2),
+                isTemporary: false,
+            },
+        ]
+        listRecordingsMock.mockResolvedValue(recordings)
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        // Wait for async updateRecord to complete
+        await vi.waitFor(() => {
+            const heading = shadowQuery(el, '.storage-heading')
+            // Total = 5 MB (main) + 1 MB (sub, counted via subFilesSize) + 3 MB (main) = 9.0 MB
+            expect(heading?.textContent).toContain('9.0')
+            expect(heading?.textContent).toContain('MB')
+        })
     })
 
     test('connectedCallback sends request-recording-state message', async () => {


### PR DESCRIPTION
This pull request simplifies how storage usage is displayed in the record list UI by removing the storage quota percentage and instead showing only the total size of all recordings. The logic for calculating and displaying storage usage has been updated accordingly, and related tests and translations have been adjusted for consistency.

**UI and Logic Simplification:**

* The storage heading in the record list now displays only the total storage used (in MB), removing the percentage/quota information. The calculation now sums the sizes of all records, including sub-files, for a more accurate total. (`src/element/recordList.ts`, [[1]](diffhunk://#diff-6384fed49d960793ab61b9f71ac7fb91928ff924951e5f6431f883e854a643a7L441-L450) [[2]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L303-R299)
* The logic and property for tracking storage quota/estimate have been removed, including related async update methods and UI updates. (`src/element/recordList.ts`, [[1]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L134-L136) [[2]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L157) [[3]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L168) [[4]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L206) [[5]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L387-L391) [[6]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L573-L575)

**Localization Updates:**

* The English and Japanese translations for the storage heading have been updated to remove the percentage placeholder and reference only the total size. (`extension/_locales/en/messages.json`, [[1]](diffhunk://#diff-6384fed49d960793ab61b9f71ac7fb91928ff924951e5f6431f883e854a643a7L441-L450); `extension/_locales/ja/messages.json`, [[2]](diffhunk://#diff-5982590837dd44122bf0f35d85581d63a73a0f9f2c10cb334a76d0a7d7bb3d25L336-L342)

**Testing Improvements:**

* Tests have been updated to check for the new storage heading format (total MB only, no percentage), and a new test ensures the sum includes sub-file sizes. (`tests/element/recordList.test.ts`, [tests/element/recordList.test.tsL132-R184](diffhunk://#diff-4817799225c5ce36031b10d894d7e827e5a66fe6db1a0eee648d0888c8f71dfcL132-R184))