### PR TITLE
bump: v1.6.2

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,7 @@
     "short_name": "__MSG_appShortName__",
     "description": "__MSG_appDescription__",
     "default_locale": "en",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "minimum_chrome_version": "140",
     "icons": {
         "16": "icons/icon16.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instant-tab-recorder",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instant-tab-recorder",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "@material/web": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instant-tab-recorder",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "type": "module",
   "description": "Google Chrome Extensions Screen Recorder",
   "scripts": {


### PR DESCRIPTION
This pull request updates the version number of the project from 1.6.1 to 1.6.2 in both the Chrome extension manifest and the `package.json` file.

Version bump:

* [`extension/manifest.json`](diffhunk://#diff-1929f2f40162baf33d4a074cc7a94593fc44ffb991fd7a7f597f90643da7f7f4L7-R7): Updated the `version` field from "1.6.1" to "1.6.2" to reflect the new release version.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the `version` field from "1.6.1" to "1.6.2" for consistency with the extension manifest.