### PR TITLE
refactor: update file size formatting in UI and tests

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -166,12 +166,12 @@
         "description": "Cancel button in confirm dialog"
     },
     "confirmSizeLabel": {
-        "message": "size: $SIZE$ MB",
+        "message": "size: $SIZE$",
         "description": "File size label in confirm dialog",
         "placeholders": {
             "size": {
                 "content": "$1",
-                "example": "2.50"
+                "example": "2.50 MB"
             }
         }
     },
@@ -438,12 +438,36 @@
         "description": "Button to restore default settings"
     },
     "recordListStorage": {
-        "message": "Storage (total: $SIZE$ MB)",
+        "message": "Storage - total: $COUNT_LABEL$, $SIZE$",
         "description": "Storage heading with usage info",
         "placeholders": {
-            "size": {
+            "count_label": {
                 "content": "$1",
-                "example": "150.5"
+                "example": "12 Records"
+            },
+            "size": {
+                "content": "$2",
+                "example": "150.50 MB"
+            }
+        }
+    },
+    "recordListRecordCountOne": {
+        "message": "$COUNT$ Record",
+        "description": "Singular record count label",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "1"
+            }
+        }
+    },
+    "recordListRecordCountOther": {
+        "message": "$COUNT$ Records",
+        "description": "Plural record count label",
+        "placeholders": {
+            "count": {
+                "content": "$1",
+                "example": "12"
             }
         }
     },
@@ -490,12 +514,12 @@
         }
     },
     "recordListSeparatedSize": {
-        "message": "$SIZE$ MB separated",
+        "message": "$SIZE$ separated",
         "description": "Separated audio file size label",
         "placeholders": {
             "size": {
                 "content": "$1",
-                "example": "1.50"
+                "example": "1.50 MB"
             }
         }
     },

--- a/extension/_locales/ja/messages.json
+++ b/extension/_locales/ja/messages.json
@@ -127,7 +127,7 @@
         "message": "キャンセル"
     },
     "confirmSizeLabel": {
-        "message": "サイズ: $SIZE$ MB",
+        "message": "サイズ: $SIZE$",
         "placeholders": {
             "size": {
                 "content": "$1"
@@ -333,9 +333,20 @@
         "message": "デフォルト設定に戻す"
     },
     "recordListStorage": {
-        "message": "ストレージ (合計: $SIZE$ MB)",
+        "message": "ストレージ - 合計: $COUNT_LABEL$, $SIZE$",
         "placeholders": {
+            "count_label": {
+                "content": "$1"
+            },
             "size": {
+                "content": "$2"
+            }
+        }
+    },
+    "recordListRecordCountOther": {
+        "message": "$COUNT$ 件",
+        "placeholders": {
+            "count": {
                 "content": "$1"
             }
         }
@@ -373,7 +384,7 @@
         }
     },
     "recordListSeparatedSize": {
-        "message": "分離された音声 $SIZE$ MB",
+        "message": "分離された音声 $SIZE$",
         "placeholders": {
             "size": {
                 "content": "$1"

--- a/src/element/confirm.ts
+++ b/src/element/confirm.ts
@@ -7,7 +7,7 @@ import '@material/web/button/filled-tonal-button'
 import '@material/web/list/list'
 import '@material/web/list/list-item'
 import '@material/web/divider/divider'
-import { formatNum } from './util'
+import { formatFileSize } from './util'
 import { RecordEntry } from './recordList'
 import { t } from '../i18n'
 
@@ -47,10 +47,7 @@ export default class Confirm extends LitElement {
                                 <md-list-item
                                     >${record.title}
                                     <div slot="end">
-                                        (${t(
-                                            'confirmSizeLabel',
-                                            formatNum((record.size + record.subFilesSize) / 1024 / 1024, 2),
-                                        )})
+                                        (${t('confirmSizeLabel', formatFileSize(record.size + record.subFilesSize))})
                                     </div></md-list-item
                                 >
                             `,

--- a/src/element/recordList.ts
+++ b/src/element/recordList.ts
@@ -1,7 +1,7 @@
 import { html, css, LitElement } from 'lit'
 import { customElement, property, state } from 'lit/decorators.js'
 import { repeat } from 'lit/directives/repeat.js'
-import { formatNum, checkFileHandlePermission } from './util'
+import { formatFileSize, checkFileHandlePermission } from './util'
 import '@material/web/list/list'
 import '@material/web/list/list-item'
 import '@material/web/divider/divider'
@@ -130,6 +130,14 @@ export class RecordList extends LitElement {
         second: '2-digit',
     })
 
+    private static readonly uiLanguage = chrome?.i18n?.getMessage?.('@@ui_locale') || 'en'
+    private static readonly pluralRules = new Intl.PluralRules(RecordList.uiLanguage)
+    private static formatRecordCount(count: number): string {
+        const category = RecordList.pluralRules.select(count)
+        const key = category === 'one' ? 'recordListRecordCountOne' : 'recordListRecordCountOther'
+        return t(key, count.toString())
+    }
+
     @property({ type: Array })
     private records: Array<RecordEntry>
 
@@ -256,13 +264,10 @@ export class RecordList extends LitElement {
                               >`
                           })}
                     <div class="meta" title=${t('recordListTitleFileSize')}>
-                        <md-icon>storage</md-icon> ${formatNum((record.size + record.subFilesSize) / 1024 / 1024, 2)} MB
+                        <md-icon>storage</md-icon> ${formatFileSize(record.size + record.subFilesSize)}
                         ${record.subFilesSize > 0
                             ? html` <span class="separated-size" title=${t('recordListTitleSeparatedSize')}
-                                  >(${t(
-                                      'recordListSeparatedSize',
-                                      formatNum(record.subFilesSize / 1024 / 1024, 2),
-                                  )})</span
+                                  >(${t('recordListSeparatedSize', formatFileSize(record.subFilesSize))})</span
                               >`
                             : ''}
                     </div>
@@ -306,7 +311,8 @@ export class RecordList extends LitElement {
         const totalSize = this.records.reduce((sum, r) => sum + r.size + r.subFilesSize, 0)
         const sortIcon = this.sortOrder === 'asc' ? 'arrow_upward' : 'arrow_downward'
         const sortLabel = this.sortOrder === 'asc' ? t('recordListSortAsc') : t('recordListSortDesc')
-        return html` <h2 class="storage-heading">${t('recordListStorage', [formatNum(totalSize / 1024 / 1024, 1)])}</h2>
+        const countLabel = RecordList.formatRecordCount(this.records.length)
+        return html` <h2 class="storage-heading">${t('recordListStorage', [countLabel, formatFileSize(totalSize)])}</h2>
             <md-chip-set class="selected-actions">
                 <md-filter-chip
                     label=${t('recordListSelectAll')}

--- a/src/element/util.ts
+++ b/src/element/util.ts
@@ -7,6 +7,17 @@ export function formatNum(num: number, dig: number) {
     })
 }
 
+export function formatFileSize(bytes: number, fractionDigits: number = 2): string {
+    const units = ['B', 'KB', 'MB', 'GB', 'TB']
+    let unitIndex = 0
+    let size = bytes
+    while (size >= 1024 && unitIndex < units.length - 1) {
+        size /= 1024
+        unitIndex++
+    }
+    return `${formatNum(size, unitIndex === 0 ? 0 : fractionDigits)} ${units[unitIndex]}`
+}
+
 export function formatRate(rate: number, dig: number) {
     return rate.toLocaleString('en-US', {
         style: 'percent',

--- a/tests/element/recordList.test.ts
+++ b/tests/element/recordList.test.ts
@@ -129,15 +129,41 @@ describe('record-list', () => {
         expect(chipSet).not.toBeNull()
     })
 
-    test('storage heading includes total and MB', async () => {
+    test('storage heading includes record count and file size', async () => {
         const screen = render(html`<record-list></record-list>`)
         const el = screen.container.querySelector('record-list')!
         await elementUpdated(el)
 
         const heading = shadowQuery(el, '.storage-heading')
         expect(heading?.textContent).toContain('total:')
-        expect(heading?.textContent).toContain('MB')
-        expect(heading?.textContent).not.toContain('%')
+        expect(heading?.textContent).toContain('0 Records')
+        expect(heading?.textContent).toContain('0 B')
+    })
+
+    test('storage heading shows singular record count for one recording', async () => {
+        const ts = '1000000000000'
+        listRecordingsMock.mockResolvedValue([
+            {
+                title: `video-${ts}.webm`,
+                size: 1024,
+                lastModified: Date.now(),
+                mimeType: 'video/webm',
+                recordedAt: Number(ts),
+                isTemporary: false,
+                subFiles: [],
+                subFilesSize: 0,
+            },
+        ])
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const heading = shadowQuery(el, '.storage-heading')
+            expect(heading?.textContent).toContain('1 Record')
+            expect(heading?.textContent).not.toContain('1 Records')
+        })
     })
 
     test('storage heading shows sum of record sizes including subFilesSize', async () => {
@@ -174,9 +200,10 @@ describe('record-list', () => {
         // Wait for async updateRecord to complete
         await vi.waitFor(() => {
             const heading = shadowQuery(el, '.storage-heading')
-            // Total = 5 MB (main) + 1 MB (sub, counted via subFilesSize) + 3 MB (main) = 9.0 MB
-            expect(heading?.textContent).toContain('9.0')
-            expect(heading?.textContent).toContain('MB')
+            // 2 recordings total
+            expect(heading?.textContent).toContain('2 Records')
+            // Total = 5 MB (main) + 1 MB (sub, counted via subFilesSize) + 3 MB (main) = 9.00 MB
+            expect(heading?.textContent).toContain('9.00 MB')
         })
     })
 

--- a/tests/element/util.test.ts
+++ b/tests/element/util.test.ts
@@ -1,4 +1,12 @@
-import { formatNum, formatRate, deepMerge, roundToEven, clampCoordinate, clampDimension } from '../../src/element/util'
+import {
+    formatNum,
+    formatRate,
+    formatFileSize,
+    deepMerge,
+    roundToEven,
+    clampCoordinate,
+    clampDimension,
+} from '../../src/element/util'
 
 describe('formatNum', () => {
     test('formats integer with specified decimal places', () => {
@@ -43,6 +51,37 @@ describe('formatRate', () => {
 
     test('formats negative rate', () => {
         expect(formatRate(-0.1, 1)).toBe('-10.0%')
+    })
+})
+
+describe('formatFileSize', () => {
+    test('formats bytes', () => {
+        expect(formatFileSize(0)).toBe('0 B')
+        expect(formatFileSize(500)).toBe('500 B')
+        expect(formatFileSize(1023)).toBe('1,023 B')
+    })
+
+    test('formats kilobytes', () => {
+        expect(formatFileSize(1024)).toBe('1.00 KB')
+        expect(formatFileSize(1536)).toBe('1.50 KB')
+    })
+
+    test('formats megabytes', () => {
+        expect(formatFileSize(1048576)).toBe('1.00 MB')
+        expect(formatFileSize(1572864)).toBe('1.50 MB')
+    })
+
+    test('formats gigabytes', () => {
+        expect(formatFileSize(1073741824)).toBe('1.00 GB')
+    })
+
+    test('formats terabytes', () => {
+        expect(formatFileSize(1099511627776)).toBe('1.00 TB')
+    })
+
+    test('respects custom fractionDigits', () => {
+        expect(formatFileSize(1048576, 1)).toBe('1.0 MB')
+        expect(formatFileSize(1572864, 3)).toBe('1.500 MB')
     })
 })
 


### PR DESCRIPTION
This pull request improves how file sizes are displayed throughout the UI by introducing a new `formatFileSize` utility, updating all relevant UI components to use this function, and adjusting localization strings for both English and Japanese to better support flexible file size formatting. It also updates tests to reflect these changes and adds comprehensive tests for the new utility.

**Localization and UI improvements:**

* Updated English and Japanese localization strings in `messages.json` to remove hardcoded "MB" units, allowing dynamic units (B, KB, MB, etc.) and to include record counts in storage headings. [[1]](diffhunk://#diff-6384fed49d960793ab61b9f71ac7fb91928ff924951e5f6431f883e854a643a7L169-R174) [[2]](diffhunk://#diff-6384fed49d960793ab61b9f71ac7fb91928ff924951e5f6431f883e854a643a7L441-R450) [[3]](diffhunk://#diff-6384fed49d960793ab61b9f71ac7fb91928ff924951e5f6431f883e854a643a7L493-R502) [[4]](diffhunk://#diff-5982590837dd44122bf0f35d85581d63a73a0f9f2c10cb334a76d0a7d7bb3d25L130-R130) [[5]](diffhunk://#diff-5982590837dd44122bf0f35d85581d63a73a0f9f2c10cb334a76d0a7d7bb3d25L336-R342) [[6]](diffhunk://#diff-5982590837dd44122bf0f35d85581d63a73a0f9f2c10cb334a76d0a7d7bb3d25L376-R379)
* Updated UI components in `src/element/confirm.ts` and `src/element/recordList.ts` to use the new `formatFileSize` function for displaying file sizes, ensuring consistent and user-friendly formatting. [[1]](diffhunk://#diff-80da059d13546819162c9cc43b951d248ce7418574fbf0e24f45fa0bb52f645eL10-R10) [[2]](diffhunk://#diff-80da059d13546819162c9cc43b951d248ce7418574fbf0e24f45fa0bb52f645eL50-R50) [[3]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L4-R4) [[4]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L259-R262) [[5]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L309-R308)

**Utility and testing enhancements:**

* Added a new `formatFileSize` function to `src/element/util.ts` that automatically selects the appropriate unit (B, KB, MB, etc.) and formats the number with the correct precision.
* Updated and expanded tests in `tests/element/recordList.test.ts` and `tests/element/util.test.ts` to cover the new formatting logic and ensure correct display of file sizes and record counts. [[1]](diffhunk://#diff-4817799225c5ce36031b10d894d7e827e5a66fe6db1a0eee648d0888c8f71dfcL132-R140) [[2]](diffhunk://#diff-4817799225c5ce36031b10d894d7e827e5a66fe6db1a0eee648d0888c8f71dfcR177-R180) [[3]](diffhunk://#diff-19247172c41780f41fa1a011f0c9c03615c3c95483250c7bebbc224ac567a100L1-R9) [[4]](diffhunk://#diff-19247172c41780f41fa1a011f0c9c03615c3c95483250c7bebbc224ac567a100R57-R87)