### PR TITLE
fix: improve error handling for recording cancellation and display alert on option page

### DIFF
--- a/src/service_worker.ts
+++ b/src/service_worker.ts
@@ -327,6 +327,12 @@ async function cancelRecording(error: string) {
     const msg: CancelRecordingMessage = { type: 'cancel-recording' }
     await chrome.runtime.sendMessage(msg)
 
+    // Persist error BEFORE broadcasting state so that the option page
+    // (if already open) can read it when handling the recording-state message.
+    if (error !== '') {
+        await chrome.storage.local.set({ lastRecordingError: error })
+    }
+
     await broadcastRecordingState()
     await updateRecordingIndications()
 
@@ -334,8 +340,6 @@ async function cancelRecording(error: string) {
     await chrome.offscreen.closeDocument()
 
     if (error === '') return
-    // Persist error for option page to display
-    await chrome.storage.local.set({ lastRecordingError: error })
     // Open option page to show the error
     await chrome.runtime.openOptionsPage()
 }

--- a/tests/element/recordList.test.ts
+++ b/tests/element/recordList.test.ts
@@ -4,6 +4,7 @@ import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { shadowQuery, elementUpdated } from './test-helpers'
 import { getChromeMock, getMessageListenersCount, simulateChromeMessage } from './test-setup'
 import '../../src/element/recordList'
+import '../../src/element/alert'
 import type { RecordingMetadata } from '../../src/storage'
 
 // Mock the api_client module used by RecordList
@@ -348,6 +349,59 @@ describe('record-list', () => {
             expect(elapsedSpan!.textContent).toBe(frozenText)
         } finally {
             vi.useRealTimers()
+        }
+    })
+
+    test('shows alert dialog when lastRecordingError is in storage on recording-state message', async () => {
+        const chromeMock = getChromeMock()
+        // connectedCallback also calls checkStoredRecordingError, so return no error initially
+        chromeMock.storage.local.get.mockResolvedValueOnce({})
+        // The recording-state handler path should find the error
+        chromeMock.storage.local.get.mockResolvedValueOnce({ lastRecordingError: 'test recording error' })
+
+        // Place extension-alert in the document (as option.html does)
+        const alertEl = document.createElement('extension-alert')
+        alertEl.id = 'alert-dialog'
+        document.body.appendChild(alertEl)
+
+        try {
+            const screen = render(html`<record-list></record-list>`)
+            const el = screen.container.querySelector('record-list')!
+            await elementUpdated(el)
+
+            // Wait for connectedCallback's async work to finish (consumes the first mock)
+            await vi.waitFor(() => {
+                expect(chromeMock.storage.local.get).toHaveBeenCalledTimes(1)
+            })
+            // Confirm no alert was opened from connectedCallback
+            const dialogBefore = alertEl.shadowRoot?.querySelector('md-dialog')
+            expect(dialogBefore?.hasAttribute('open')).not.toBe(true)
+
+            // Simulate a recording-state message (triggers checkStoredRecordingError)
+            simulateChromeMessage({
+                type: 'recording-state',
+                data: { isRecording: false },
+            })
+
+            await vi.waitFor(() => {
+                // Verify the error was read (twice total) and removed from storage
+                expect(chromeMock.storage.local.get).toHaveBeenCalledTimes(2)
+                expect(chromeMock.storage.local.get).toHaveBeenCalledWith('lastRecordingError')
+                expect(chromeMock.storage.local.remove).toHaveBeenCalledWith('lastRecordingError')
+
+                // Verify the alert dialog is open with the correct content
+                const dialog = alertEl.shadowRoot?.querySelector('md-dialog') as
+                    | (HTMLElement & { open?: boolean })
+                    | null
+                expect(dialog).not.toBeNull()
+                expect(dialog?.open).toBe(true)
+                const headline = alertEl.shadowRoot?.querySelector('[slot="headline"]')
+                expect(headline?.textContent).toBe('Recording Failed')
+                const content = alertEl.shadowRoot?.querySelector('[slot="content"]')
+                expect(content?.textContent).toContain('test recording error')
+            })
+        } finally {
+            alertEl.remove()
         }
     })
 })


### PR DESCRIPTION
This pull request improves the reliability of error handling and user feedback when a recording error occurs, and adds a new test to ensure this behavior is working as intended. The main focus is on ensuring that error messages are available to the options page as soon as possible and that the alert dialog displays recording errors correctly.

**Error handling improvements:**

* In `src/service_worker.ts`, the error message is now persisted to storage before broadcasting the recording state, ensuring that the options page can immediately access and display the error when it receives the state update.

**Testing enhancements:**

* In `tests/element/recordList.test.ts`, a new test was added to verify that when a `lastRecordingError` is present in storage, the alert dialog is shown with the correct error message upon receiving a `recording-state` message. This test also checks that the error is read and then removed from storage.
* The alert component is now imported in the test file to support the new test for error display.