### PR TITLE
feat: add thumbnail generation for recordings and update UI components

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -527,6 +527,14 @@
         "message": "Recording",
         "description": "Status label for active recording"
     },
+    "recordListThumbnailRecording": {
+        "message": "Recording",
+        "description": "Label shown in thumbnail area while recording"
+    },
+    "recordListThumbnailUnavailable": {
+        "message": "No Thumbnail",
+        "description": "Label shown in thumbnail area when thumbnail is unavailable"
+    },
     "recordListPaused": {
         "message": "Paused",
         "description": "Status label for paused recording"

--- a/extension/_locales/ja/messages.json
+++ b/extension/_locales/ja/messages.json
@@ -394,6 +394,12 @@
     "recordListRecording": {
         "message": "録画中"
     },
+    "recordListThumbnailRecording": {
+        "message": "録画中"
+    },
+    "recordListThumbnailUnavailable": {
+        "message": "サムネイルなし"
+    },
     "recordListPaused": {
         "message": "一時停止"
     },

--- a/extension/option.html
+++ b/extension/option.html
@@ -10,7 +10,7 @@
         }
 
         .container {
-            width: 600px;
+            width: 640px;
             position: relative;
             margin: auto;
         }

--- a/src/element/recordList.ts
+++ b/src/element/recordList.ts
@@ -38,6 +38,7 @@ export interface RecordEntry {
     durationMs?: number | null
     subFiles: SubFileInfo[] // Related audio separation files from IndexedDB
     subFilesSize: number // Total size of sub-files in bytes
+    thumbnailFileName?: string
 }
 
 /**
@@ -86,6 +87,17 @@ export class RecordList extends LitElement {
         .list-item {
             font-variant-numeric: tabular-nums;
         }
+        .start-slot {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+        }
+        .list-item md-checkbox {
+            margin: 0;
+        }
+        .recording-title {
+            height: 30px;
+        }
         .recording {
             color: var(--theme-recording, #d93025);
         }
@@ -119,6 +131,44 @@ export class RecordList extends LitElement {
         a {
             color: var(--theme-link, inherit);
         }
+        .item-content {
+            flex: 1;
+            min-width: 0;
+        }
+        .thumbnail-container {
+            width: 192px;
+            height: 108px;
+            border-radius: 4px;
+            flex-shrink: 0;
+            overflow: hidden;
+        }
+        .thumbnail-container img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            display: block;
+        }
+        .thumbnail-placeholder {
+            width: 100%;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: var(--theme-surface-variant, #dae5e3);
+            color: var(--theme-text-secondary, #3f4948);
+            font-size: 0.875rem;
+        }
+        .thumbnail-recording {
+            width: 100%;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: var(--theme-surface-variant, #dae5e3);
+            color: var(--theme-recording, #d93025);
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
     `
 
     private static readonly dateTimeFormat = new Intl.DateTimeFormat(undefined, {
@@ -149,6 +199,9 @@ export class RecordList extends LitElement {
 
     @state()
     private timerStopText: string = ''
+
+    @state()
+    private failedThumbnailKeys: Set<string> = new Set()
 
     private recordingStartAtMs: number | null = null
     private recordingStopAtMs: number | null = null
@@ -234,75 +287,111 @@ export class RecordList extends LitElement {
         dialog?.show()
     }
 
+    private static getThumbnailKey(record: Pick<RecordEntry, 'path' | 'thumbnailFileName'>): string | null {
+        if (!record.thumbnailFileName) return null
+        return `${record.path}::${record.thumbnailFileName}`
+    }
+
+    private hasThumbnailLoadFailed(record: Pick<RecordEntry, 'path' | 'thumbnailFileName'>): boolean {
+        const key = RecordList.getThumbnailKey(record)
+        return key != null && this.failedThumbnailKeys.has(key)
+    }
+
+    private handleThumbnailError(record: Pick<RecordEntry, 'path' | 'thumbnailFileName'>) {
+        const key = RecordList.getThumbnailKey(record)
+        if (key == null || this.failedThumbnailKeys.has(key)) return
+        const next = new Set(this.failedThumbnailKeys)
+        next.add(key)
+        this.failedThumbnailKeys = next
+    }
+
     public override render() {
         const row = (record: RecordEntry, idx: number) => {
             const fileUrl = getRecordingFileUrl(record.path)
             const downloadUrl = `${fileUrl}?download=true`
             return html` ${idx > 0 ? html`<md-divider></md-divider>` : ''}
                 <md-list-item class="list-item">
-                    <md-checkbox
-                        touch-target="wrapper"
-                        slot="start"
-                        ?disabled=${record.isRecording}
-                        ?checked=${record.selected}
-                        @input=${this.selectRecord(record)}></md-checkbox>
-                    ${record.isRecording
-                        ? html`<span aria-disabled="true">${record.title}</span>`
-                        : html`<a href="${downloadUrl}">${record.title}</a>`}
-                    ${record.isRecording
-                        ? ''
-                        : record.subFiles.map(sub => {
-                              const subUrl = `${getRecordingFileUrl(sub.path)}?download=true`
-                              const label = sub.type === 'tab' ? t('recordListTabAudio') : t('recordListMicAudio')
-                              const icon = sub.type === 'tab' ? 'headphones' : 'mic'
-                              return html`<a
-                                  href="${subUrl}"
-                                  title="${label}"
-                                  aria-label="${t('recordListDownloadLabel', label)}"
-                                  class="sub-file-icon"
-                                  ><md-icon>${icon}</md-icon></a
-                              >`
-                          })}
-                    <div class="meta" title=${t('recordListTitleFileSize')}>
-                        <md-icon>storage</md-icon> ${formatFileSize(record.size + record.subFilesSize)}
-                        ${record.subFilesSize > 0
-                            ? html` <span class="separated-size" title=${t('recordListTitleSeparatedSize')}
-                                  >(${t('recordListSeparatedSize', formatFileSize(record.subFilesSize))})</span
-                              >`
+                    <div slot="start" class="start-slot">
+                        <md-checkbox
+                            touch-target="wrapper"
+                            ?disabled=${record.isRecording}
+                            ?checked=${record.selected}
+                            @input=${this.selectRecord(record)}></md-checkbox>
+                        <div class="thumbnail-container">
+                            ${record.isRecording
+                                ? html`<div class="thumbnail-recording">${t('recordListThumbnailRecording')}</div>`
+                                : record.thumbnailFileName && !this.hasThumbnailLoadFailed(record)
+                                  ? html`<img
+                                        src="${getRecordingFileUrl(record.thumbnailFileName)}"
+                                        alt=""
+                                        loading="lazy"
+                                        @error=${() => this.handleThumbnailError(record)} />`
+                                  : html`<div class="thumbnail-placeholder">
+                                        ${t('recordListThumbnailUnavailable')}
+                                    </div>`}
+                        </div>
+                    </div>
+                    <div class="recording-title" slot="headline">
+                        ${record.isRecording
+                            ? html`<span aria-disabled="true">${record.title}</span>`
+                            : html`<a href="${downloadUrl}">${record.title}</a>`}
+                        ${record.isRecording
+                            ? ''
+                            : record.subFiles.map(sub => {
+                                  const subUrl = `${getRecordingFileUrl(sub.path)}?download=true`
+                                  const label = sub.type === 'tab' ? t('recordListTabAudio') : t('recordListMicAudio')
+                                  const icon = sub.type === 'tab' ? 'headphones' : 'mic'
+                                  return html`<a
+                                      href="${subUrl}"
+                                      title="${label}"
+                                      aria-label="${t('recordListDownloadLabel', label)}"
+                                      class="sub-file-icon"
+                                      ><md-icon>${icon}</md-icon></a
+                                  >`
+                              })}
+                    </div>
+                    <div class="item-content" slot="supporting-text">
+                        <div class="meta" title=${t('recordListTitleFileSize')}>
+                            <md-icon>storage</md-icon> ${formatFileSize(record.size + record.subFilesSize)}
+                            ${record.subFilesSize > 0
+                                ? html` <span class="separated-size" title=${t('recordListTitleSeparatedSize')}
+                                      >(${t('recordListSeparatedSize', formatFileSize(record.subFilesSize))})</span
+                                  >`
+                                : ''}
+                        </div>
+                        ${record.recordedAt != null
+                            ? html`<div class="meta" title=${t('recordListTitleRecordedAt')}>
+                                  <md-icon>schedule</md-icon>
+                                  ${RecordList.dateTimeFormat.format(record.recordedAt)}
+                              </div>`
+                            : ''}
+                        ${record.durationMs != null && !record.isRecording
+                            ? html`<div class="meta" title=${t('recordListTitleDuration')}>
+                                  <md-icon>timer</md-icon> ${formatElapsedTime(record.durationMs)}
+                              </div>`
+                            : ''}
+                        ${record.isRecording
+                            ? html`<div class="meta recording" title=${t('recordListTitleRecording')}>
+                                  <md-icon>screen_record</md-icon>
+                                  ${this.recordingPaused ? t('recordListPaused') : t('recordListRecording')}
+                                  <span class="elapsed-time${this.recordingPaused ? ' elapsed-blink' : ''}"
+                                      >${this.elapsedTimeText}</span
+                                  >${this.timerStopText
+                                      ? html` <span title=${t('recordListTitleTimerStop')}
+                                            >(⏱
+                                            ${this.recordingPaused
+                                                ? t('recordListTimerPaused')
+                                                : t('recordListTimerStopsAt', this.timerStopText)})</span
+                                        >`
+                                      : ''}
+                              </div>`
+                            : ''}
+                        ${record.isCanceled
+                            ? html`<div class="meta canceled" title=${t('recordListTitleCanceled')}>
+                                  <md-icon>cancel</md-icon> ${t('recordListCanceled')}
+                              </div>`
                             : ''}
                     </div>
-                    ${record.recordedAt != null
-                        ? html`<div class="meta" title=${t('recordListTitleRecordedAt')}>
-                              <md-icon>schedule</md-icon> ${RecordList.dateTimeFormat.format(record.recordedAt)}
-                          </div>`
-                        : ''}
-                    ${record.durationMs != null && !record.isRecording
-                        ? html`<div class="meta" title=${t('recordListTitleDuration')}>
-                              <md-icon>timer</md-icon> ${formatElapsedTime(record.durationMs)}
-                          </div>`
-                        : ''}
-                    ${record.isRecording
-                        ? html`<div class="meta recording" title=${t('recordListTitleRecording')}>
-                              <md-icon>screen_record</md-icon> ${this.recordingPaused
-                                  ? t('recordListPaused')
-                                  : t('recordListRecording')}
-                              <span class="elapsed-time${this.recordingPaused ? ' elapsed-blink' : ''}"
-                                  >${this.elapsedTimeText}</span
-                              >${this.timerStopText
-                                  ? html` <span title=${t('recordListTitleTimerStop')}
-                                        >(⏱
-                                        ${this.recordingPaused
-                                            ? t('recordListTimerPaused')
-                                            : t('recordListTimerStopsAt', this.timerStopText)})</span
-                                    >`
-                                  : ''}
-                          </div>`
-                        : ''}
-                    ${record.isCanceled
-                        ? html`<div class="meta canceled" title=${t('recordListTitleCanceled')}>
-                              <md-icon>cancel</md-icon> ${t('recordListCanceled')}
-                          </div>`
-                        : ''}
                     <md-filled-icon-button slot="end" ?disabled=${record.isRecording} @click=${this.playRecord(record)}>
                         <md-icon>play_arrow</md-icon>
                     </md-filled-icon-button>
@@ -363,10 +452,20 @@ export class RecordList extends LitElement {
             durationMs: meta.durationMs,
             subFiles: meta.subFiles ?? [],
             subFilesSize: meta.subFilesSize ?? 0,
+            thumbnailFileName: meta.thumbnailFileName,
         }))
 
         const oldVal = [...this.records]
         this.records = result
+        const validThumbnailKeys = new Set(
+            result.map(r => RecordList.getThumbnailKey(r)).filter((key): key is string => key != null),
+        )
+        if (this.failedThumbnailKeys.size > 0) {
+            const retainedFailedKeys = new Set([...this.failedThumbnailKeys].filter(key => validThumbnailKeys.has(key)))
+            if (retainedFailedKeys.size !== this.failedThumbnailKeys.size) {
+                this.failedThumbnailKeys = retainedFailedKeys
+            }
+        }
         this.requestUpdate('records', oldVal)
     }
 

--- a/src/element/settings.ts
+++ b/src/element/settings.ts
@@ -98,6 +98,9 @@ export class Settings extends LitElement {
         md-filled-select {
             margin-bottom: 1em;
         }
+        .recording-scale-input {
+            width: 140px;
+        }
         .video-format-input {
             width: 280px;
         }
@@ -220,6 +223,7 @@ export class Settings extends LitElement {
                 .value=${live(this.config.screenRecordingSize.height)}
                 @change=${this.updateProp('screenRecordingSize', 'height')}></md-filled-text-field>
             <md-filled-text-field
+                class="recording-scale-input"
                 label=${t('settingsRecordingScale')}
                 type="number"
                 min="1"

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -92,7 +92,8 @@ export interface RecordingState {
  * Supports:
  * - GET  /api/storage/estimate              - Storage quota info
  * - GET  /api/recordings                    - List recordings (from IndexedDB)
- * - GET  /api/recordings/:name              - Download recording (with Range Request support)
+ * - GET  /api/recordings/:name                    - Download recording (with Range Request support)
+ * - GET  /api/recordings/video-{ts}-thumbnail.webp - Get recording thumbnail (served as WebP)
  * - DELETE /api/recordings/:name            - Delete recording (cascade: IndexedDB + OPFS)
  */
 export async function handleApiRequest(
@@ -169,6 +170,7 @@ export async function handleApiRequest(
 
                         const subFilesSize = r.subFiles.reduce((sum, sf) => sum + sf.fileSize, 0)
 
+                        const thumbnailFileName = r.thumbnail ? `video-${r.recordedAt}-thumbnail.webp` : undefined
                         return {
                             title: r.title || r.mainFilePath,
                             path: r.mainFilePath,
@@ -182,6 +184,7 @@ export async function handleApiRequest(
                             status,
                             subFiles: r.subFiles,
                             subFilesSize,
+                            ...(thumbnailFileName ? { thumbnailFileName } : {}),
                         }
                     }),
                 )
@@ -199,6 +202,30 @@ export async function handleApiRequest(
 
             case 'recording': {
                 const name = parsed.name!
+                const mimeType = getMimeTypeFromExtension(name)
+
+                // Thumbnail files are read-only: video-{timestamp}-thumbnail.webp
+                const thumbnailMatch = name.match(/^video-([0-9]+)-thumbnail\.webp$/)
+                if (thumbnailMatch) {
+                    if (request.method !== 'GET') {
+                        return new Response(JSON.stringify({ error: 'Method Not Allowed' }), {
+                            status: 405,
+                            headers: { 'Content-Type': 'application/json' },
+                        })
+                    }
+                    const thumbRecordedAt = Number.parseInt(thumbnailMatch[1], 10)
+                    const thumbRecord = await recordingDB.get(thumbRecordedAt)
+                    if (!thumbRecord?.thumbnail) {
+                        return new Response(JSON.stringify({ error: 'Not Found' }), {
+                            status: 404,
+                            headers: { 'Content-Type': 'application/json' },
+                        })
+                    }
+                    return new Response(thumbRecord.thumbnail, {
+                        status: 200,
+                        headers: { 'Content-Type': mimeType },
+                    })
+                }
 
                 if (request.method === 'DELETE') {
                     // Look up IndexedDB record by timestamp for cascade delete
@@ -261,7 +288,6 @@ export async function handleApiRequest(
                         headers: { 'Content-Type': 'application/json' },
                     })
                 }
-                const mimeType = getMimeTypeFromExtension(name)
                 const headers: Record<string, string> = {
                     'Content-Type': mimeType,
                     'Accept-Ranges': 'bytes',

--- a/src/mime.ts
+++ b/src/mime.ts
@@ -7,6 +7,7 @@ const extensionToMimeType: Record<string, string> = {
     '.ogg': 'audio/ogg',
     '.aac': 'audio/aac',
     '.flac': 'audio/flac',
+    '.webp': 'image/webp',
 }
 
 /**

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -67,6 +67,11 @@ const handler = new OffscreenHandler({
         window.location.hash = hash
     },
     recordingDB,
+    getVideoFile: async (path: string) => {
+        const dirHandle = await navigator.storage.getDirectory()
+        const fileHandle = await dirHandle.getFileHandle(path)
+        return await fileHandle.getFile()
+    },
 })
 
 chrome.runtime.onMessage.addListener(

--- a/src/offscreen_handler.ts
+++ b/src/offscreen_handler.ts
@@ -11,6 +11,7 @@ import type {
 import type { RecordingConfig, RecordingResult } from './recorder'
 import type { Event, ExceptionMetadata } from './sentry_event'
 import type { RecordingDB, RecordingRecord } from './recording_db'
+import { generateThumbnail } from './thumbnail'
 
 // ---------- dependency interfaces ----------
 
@@ -40,6 +41,7 @@ export interface OffscreenDeps {
     getLocationHash(): string
     setLocationHash(hash: string): void
     recordingDB: RecordingDB
+    getVideoFile(path: string): Promise<File>
 }
 
 // ---------- handler ----------
@@ -147,6 +149,16 @@ export class OffscreenHandler {
         try {
             const result = await this.deps.session.stop()
             if (result) {
+                // Generate thumbnail from the recorded video (non-fatal)
+                let thumbnail: Blob | null = null
+                try {
+                    const videoFile = await this.deps.getVideoFile(result.mainFilePath)
+                    thumbnail = await generateThumbnail(videoFile)
+                } catch (e) {
+                    console.error('Failed to generate thumbnail:', e)
+                    this.deps.sendException(e, { exceptionSource: 'offscreen.stopRecording.thumbnail' })
+                }
+
                 // Update IndexedDB record with final metadata
                 try {
                     const record: RecordingRecord = {
@@ -158,6 +170,7 @@ export class OffscreenHandler {
                         durationMs: result.durationMs,
                         fileSize: result.fileSize,
                         subFiles: result.subFiles,
+                        thumbnail,
                     }
                     await this.deps.recordingDB.put(record)
                 } catch (e) {

--- a/src/recording_db.ts
+++ b/src/recording_db.ts
@@ -43,6 +43,8 @@ export interface RecordingRecord {
     fileSize: number
     /** Sub-files (tab audio, mic audio) */
     subFiles: SubFileInfo[]
+    /** WebP thumbnail blob, null when generation failed, undefined for legacy records */
+    thumbnail?: Blob | null
 }
 
 function openDB(): Promise<IDBDatabase> {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -23,6 +23,8 @@ export interface RecordingMetadata {
     status?: 'recording' | 'completed' | 'canceled'
     subFiles?: SubFileInfo[]
     subFilesSize?: number
+    /** Thumbnail file name for API fetch, present only when thumbnail exists (e.g. "video-1234-thumbnail.webp") */
+    thumbnailFileName?: string
 }
 
 /**

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -46,6 +46,7 @@ function injectThemeStyles() {
 html[data-theme="light"] {
     --theme-bg: #f8f9fa;
     --theme-surface: #ffffff;
+    --theme-surface-variant: #e8e8f0;
     --theme-text: #1a1a2e;
     --theme-text-secondary: #5a5a7a;
     --theme-border: #e0e0e8;
@@ -78,6 +79,7 @@ html[data-theme="light"] {
 html[data-theme="dark"] {
     --theme-bg: #121218;
     --theme-surface: #1e1e2a;
+    --theme-surface-variant: #28283a;
     --theme-text: #e8e8f0;
     --theme-text-secondary: #a0a0b8;
     --theme-border: #2e2e40;

--- a/src/thumbnail.ts
+++ b/src/thumbnail.ts
@@ -1,0 +1,32 @@
+import { ALL_FORMATS, BlobSource, Input, VideoSampleSink } from 'mediabunny'
+
+const DEFAULT_WIDTH = 480
+const QUALITY = 0.8
+
+/**
+ * Generate a WebP thumbnail from the first frame of a video blob.
+ * Throws if thumbnail generation fails.
+ */
+export async function generateThumbnail(videoBlob: Blob, options?: { width?: number }): Promise<Blob> {
+    using input = new Input({
+        formats: ALL_FORMATS,
+        source: new BlobSource(videoBlob),
+    })
+    const videoTrack = await input.getPrimaryVideoTrack()
+    if (!videoTrack) throw new Error('failed to get video track')
+
+    const firstTimestamp = await videoTrack.getFirstTimestamp()
+    const sink = new VideoSampleSink(videoTrack)
+    using sample = await sink.getSample(firstTimestamp)
+    if (sample == null) throw new Error('failed to get video frame')
+
+    const aspectRatio = videoTrack.displayHeight / videoTrack.displayWidth
+    const width = options?.width ?? DEFAULT_WIDTH
+    const height = Math.round(width * aspectRatio)
+    const canvas = new OffscreenCanvas(width, height)
+    const ctx = canvas.getContext('2d')
+    if (ctx == null) throw new Error('failed to get canvas 2d context')
+
+    sample.drawWithFit(ctx, { fit: 'fill' })
+    return await canvas.convertToBlob({ type: 'image/webp', quality: QUALITY })
+}

--- a/tests/element/recordList.test.ts
+++ b/tests/element/recordList.test.ts
@@ -6,6 +6,7 @@ import { getChromeMock, getMessageListenersCount, simulateChromeMessage } from '
 import '../../src/element/recordList'
 import '../../src/element/alert'
 import type { RecordingMetadata } from '../../src/storage'
+import { MdCheckbox } from '@material/web/checkbox/checkbox'
 
 // Mock the api_client module used by RecordList
 const listRecordingsMock = vi.fn().mockResolvedValue([])
@@ -101,6 +102,117 @@ describe('record-list', () => {
 
         const list = shadowQuery(el, 'md-list')
         expect(list).not.toBeNull()
+    })
+
+    test('renders thumbnail image for completed recordings', async () => {
+        const ts = '1000000000000'
+        listRecordingsMock.mockResolvedValue([
+            {
+                title: `video-${ts}.webm`,
+                path: `video-${ts}.webm`,
+                size: 1024,
+                lastModified: Date.now(),
+                mimeType: 'video/webm',
+                recordedAt: Number(ts),
+                isRecording: false,
+                isTemporary: false,
+                subFiles: [],
+                subFilesSize: 0,
+                thumbnailFileName: `video-${ts}-thumbnail.webp`,
+            },
+        ])
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const img = shadowQuery(el, '.thumbnail-container img') as HTMLImageElement | null
+            expect(img).not.toBeNull()
+            expect(img?.src).toContain(`/api/recordings/video-${ts}-thumbnail.webp`)
+            expect(img?.loading).toBe('lazy')
+        })
+    })
+
+    test('keeps thumbnail placeholder after image error across re-renders', async () => {
+        const ts = '1000000000001'
+        listRecordingsMock.mockResolvedValue([
+            {
+                title: `video-${ts}.webm`,
+                path: `video-${ts}.webm`,
+                size: 1024,
+                lastModified: Date.now(),
+                mimeType: 'video/webm',
+                recordedAt: Number(ts),
+                isRecording: false,
+                isTemporary: false,
+                subFiles: [],
+                subFilesSize: 0,
+                thumbnailFileName: `video-${ts}-thumbnail.webp`,
+            },
+        ])
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const img = shadowQuery(el, '.thumbnail-container img') as HTMLImageElement | null
+            expect(img).not.toBeNull()
+        })
+
+        const img = shadowQuery(el, '.thumbnail-container img') as HTMLImageElement
+        img.dispatchEvent(new Event('error'))
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const placeholder = shadowQuery(el, '.thumbnail-container .thumbnail-placeholder')
+            expect(placeholder).not.toBeNull()
+            expect(shadowQuery(el, '.thumbnail-container img')).toBeNull()
+        })
+
+        const checkbox = shadowQuery(el, 'md-checkbox') as MdCheckbox
+        checkbox.checked = true
+        checkbox.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
+        await elementUpdated(el)
+
+        const placeholderAfterRerender = shadowQuery(el, '.thumbnail-container .thumbnail-placeholder')
+        expect(placeholderAfterRerender).not.toBeNull()
+        expect(shadowQuery(el, '.thumbnail-container img')).toBeNull()
+    })
+
+    test('renders recording indicator instead of thumbnail for recording-in-progress entries', async () => {
+        const ts = Date.now()
+        listRecordingsMock.mockResolvedValue([
+            {
+                title: `video-${ts}.webm`,
+                path: `video-${ts}.webm`,
+                size: 0,
+                lastModified: Date.now(),
+                mimeType: 'video/webm',
+                recordedAt: ts,
+                isRecording: true,
+                isTemporary: false,
+                subFiles: [],
+                subFilesSize: 0,
+            },
+        ])
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const listItem = shadowQuery(el, '.list-item')
+            expect(listItem).not.toBeNull()
+        })
+
+        const img = shadowQuery(el, '.thumbnail-container img')
+        expect(img).toBeNull()
+
+        const recording = shadowQuery(el, '.thumbnail-recording')
+        expect(recording).not.toBeNull()
+        expect(recording?.textContent).toBe('Recording')
     })
 
     test('connectedCallback registers chrome.runtime.onMessage listener', async () => {

--- a/tests/handler.test.ts
+++ b/tests/handler.test.ts
@@ -72,6 +72,13 @@ describe('parseApiPath', () => {
     it('should return null for names with encoded backslash', () => {
         expect(parseApiPath('/api/recordings/foo%5Cbar.webm')).toBeNull()
     })
+
+    it('should parse /api/recordings/video-{ts}-thumbnail.webp as recording route', () => {
+        expect(parseApiPath('/api/recordings/video-1000-thumbnail.webp')).toEqual({
+            route: 'recording',
+            name: 'video-1000-thumbnail.webp',
+        })
+    })
 })
 
 // ---------- handleApiRequest – storage-estimate ----------
@@ -189,6 +196,44 @@ describe('handleApiRequest – recordings-list', () => {
         const body = await res.json()
         const recordingEntry = body.find((r: { title: string }) => r.title === 'video-3.webm')
         expect(recordingEntry.size).toBe(500)
+    })
+
+    it('should include thumbnailFileName only when thumbnail exists', async () => {
+        const withThumbnail: RecordingRecord = {
+            recordedAt: 1000,
+            mainFilePath: 'video-1000.webm',
+            mimeType: 'video/webm',
+            title: 'video-1000.webm',
+            status: 'completed',
+            durationMs: 5000,
+            fileSize: 100,
+            subFiles: [],
+            thumbnail: new Blob(['thumb'], { type: 'image/webp' }),
+        }
+        const withoutThumbnail: RecordingRecord = {
+            recordedAt: 1001,
+            mainFilePath: 'video-1001.webm',
+            mimeType: 'video/webm',
+            title: 'video-1001.webm',
+            status: 'completed',
+            durationMs: 5000,
+            fileSize: 100,
+            subFiles: [],
+            thumbnail: null,
+        }
+        const recordingDB = createMockRecordingDB({
+            list: vi.fn().mockResolvedValue([withThumbnail, withoutThumbnail]),
+        })
+        const storage = createMockStorage()
+        const req = new Request('https://ext.example/api/recordings')
+        const res = await handleApiRequest(req, storage, { isRecording: false }, recordingDB)
+
+        expect(res.status).toBe(200)
+        const body = await res.json()
+        const first = body.find((r: { recordedAt: number }) => r.recordedAt === 1000)
+        const second = body.find((r: { recordedAt: number }) => r.recordedAt === 1001)
+        expect(first.thumbnailFileName).toBe('video-1000-thumbnail.webp')
+        expect(second.thumbnailFileName).toBeUndefined()
     })
 
     it('should pass sort=desc parameter', async () => {
@@ -758,5 +803,82 @@ describe('handleApiRequest – internal error', () => {
 
         expect(res.status).toBe(500)
         expect(await res.json()).toEqual({ error: 'Internal Server Error' })
+    })
+})
+
+// ---------- handleApiRequest – recording-thumbnail ----------
+
+describe('handleApiRequest – recording-thumbnail', () => {
+    it('should return thumbnail blob with correct content type', async () => {
+        const thumbnailBlob = new Blob(['fake-webp'], { type: 'image/webp' })
+        const record: RecordingRecord = {
+            recordedAt: 1000,
+            mainFilePath: 'video-1000.webm',
+            mimeType: 'video/webm',
+            title: 'video-1000.webm',
+            status: 'completed',
+            durationMs: 5000,
+            fileSize: 100,
+            subFiles: [],
+            thumbnail: thumbnailBlob,
+        }
+        const recordingDB = createMockRecordingDB({
+            get: vi.fn().mockResolvedValue(record),
+        })
+        const storage = createMockStorage()
+        const req = new Request('https://ext.example/api/recordings/video-1000-thumbnail.webp')
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState, recordingDB)
+
+        expect(res.status).toBe(200)
+        expect(res.headers.get('Content-Type')).toBe('image/webp')
+        const body = await res.text()
+        expect(body).toBe('fake-webp')
+    })
+
+    it('should return 404 when record has no thumbnail', async () => {
+        const record: RecordingRecord = {
+            recordedAt: 1000,
+            mainFilePath: 'video-1000.webm',
+            mimeType: 'video/webm',
+            title: 'video-1000.webm',
+            status: 'completed',
+            durationMs: 5000,
+            fileSize: 100,
+            subFiles: [],
+        }
+        const recordingDB = createMockRecordingDB({
+            get: vi.fn().mockResolvedValue(record),
+        })
+        const storage = createMockStorage()
+        const req = new Request('https://ext.example/api/recordings/video-1000-thumbnail.webp')
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState, recordingDB)
+
+        expect(res.status).toBe(404)
+    })
+
+    it('should return 404 when record not found', async () => {
+        const recordingDB = createMockRecordingDB({
+            get: vi.fn().mockResolvedValue(undefined),
+        })
+        const storage = createMockStorage()
+        const req = new Request('https://ext.example/api/recordings/video-1000-thumbnail.webp')
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState, recordingDB)
+
+        expect(res.status).toBe(404)
+    })
+
+    it('should return 405 for non-GET methods', async () => {
+        const recordingDB = createMockRecordingDB()
+        const storage = createMockStorage()
+        const req = new Request('https://ext.example/api/recordings/video-1000-thumbnail.webp', {
+            method: 'DELETE',
+        })
+        const recordingState: RecordingState = { isRecording: false, startAtMs: 0 }
+        const res = await handleApiRequest(req, storage, recordingState, recordingDB)
+
+        expect(res.status).toBe(405)
     })
 })

--- a/tests/offscreen_handler.test.ts
+++ b/tests/offscreen_handler.test.ts
@@ -7,6 +7,11 @@ vi.mock('@mediabunny/flac-encoder', () => ({
     registerFlacEncoder: vi.fn(),
 }))
 
+const generateThumbnailMock = vi.fn().mockResolvedValue(null)
+vi.mock('../src/thumbnail', () => ({
+    generateThumbnail: (...args: unknown[]) => generateThumbnailMock(...args),
+}))
+
 import { OffscreenHandler } from '../src/offscreen_handler'
 import type { OffscreenDeps, OffscreenSession } from '../src/offscreen_handler'
 import type { Message, StartRecordingResponse } from '../src/message'
@@ -60,6 +65,7 @@ function createMockRecordingDB(): RecordingDB {
 
 function createMockDeps(overrides: Partial<OffscreenDeps> = {}): OffscreenDeps {
     const defaultConfig = new Configuration()
+    const defaultVideoFile = new File(['video-data'], 'video-1000.webm', { type: 'video/webm' })
     return {
         getRecordingInfo: vi.fn().mockReturnValue({
             videoFormat: defaultConfig.videoFormat,
@@ -76,6 +82,7 @@ function createMockDeps(overrides: Partial<OffscreenDeps> = {}): OffscreenDeps {
         getLocationHash: vi.fn().mockReturnValue(''),
         setLocationHash: vi.fn(),
         recordingDB: createMockRecordingDB(),
+        getVideoFile: vi.fn().mockResolvedValue(defaultVideoFile),
         ...overrides,
     }
 }
@@ -296,6 +303,10 @@ describe('start-recording', () => {
 // ---------- stop-recording ----------
 
 describe('stop-recording', () => {
+    beforeEach(() => {
+        generateThumbnailMock.mockReset().mockResolvedValue(null)
+    })
+
     it('calls session.stop and sends stop_recording event with metrics', async () => {
         const deps = createMockDeps()
         const handler = new OffscreenHandler(deps)
@@ -391,6 +402,48 @@ describe('stop-recording', () => {
         } finally {
             vi.useRealTimers()
         }
+    })
+
+    it('generates thumbnail and stores it in IndexedDB record', async () => {
+        const fakeVideoFile = new Blob(['video-data'], { type: 'video/webm' })
+        const fakeThumbnail = new Blob(['jpeg-data'], { type: 'image/jpeg' })
+        generateThumbnailMock.mockResolvedValue(fakeThumbnail)
+        const deps = createMockDeps({
+            getVideoFile: vi.fn().mockResolvedValue(fakeVideoFile),
+        })
+        const handler = new OffscreenHandler(deps)
+        await handler.handleMessage({ type: 'stop-recording', trigger: 'action-icon' })
+
+        expect(deps.getVideoFile).toHaveBeenCalledWith('video-1000.webm')
+        expect(generateThumbnailMock).toHaveBeenCalledWith(fakeVideoFile)
+        expect(deps.recordingDB.put).toHaveBeenCalledWith(expect.objectContaining({ thumbnail: fakeThumbnail }))
+    })
+
+    it('stores null thumbnail and sends exception when getVideoFile throws', async () => {
+        const error = new Error('OPFS read failed')
+        const deps = createMockDeps({
+            getVideoFile: vi.fn().mockRejectedValue(error),
+        })
+        const handler = new OffscreenHandler(deps)
+        await handler.handleMessage({ type: 'stop-recording', trigger: 'action-icon' })
+
+        expect(generateThumbnailMock).not.toHaveBeenCalled()
+        expect(deps.sendException).toHaveBeenCalledWith(error, {
+            exceptionSource: 'offscreen.stopRecording.thumbnail',
+        })
+        expect(deps.recordingDB.put).toHaveBeenCalledWith(expect.objectContaining({ thumbnail: null }))
+    })
+
+    it('stores null thumbnail when generateThumbnail returns null', async () => {
+        const fakeVideoFile = new Blob(['video-data'], { type: 'video/webm' })
+        generateThumbnailMock.mockResolvedValue(null)
+        const deps = createMockDeps({
+            getVideoFile: vi.fn().mockResolvedValue(fakeVideoFile),
+        })
+        const handler = new OffscreenHandler(deps)
+        await handler.handleMessage({ type: 'stop-recording', trigger: 'action-icon' })
+
+        expect(deps.recordingDB.put).toHaveBeenCalledWith(expect.objectContaining({ thumbnail: null }))
     })
 })
 

--- a/tests/recording_db.browser.test.ts
+++ b/tests/recording_db.browser.test.ts
@@ -79,6 +79,34 @@ describe('RecordingDB (real IndexedDB)', () => {
         )
     })
 
+    it('stores and retrieves thumbnail blob', async () => {
+        const thumbnailBlob = new Blob(['fake-jpeg'], { type: 'image/jpeg' })
+        const record = makeRecord({ recordedAt: 3000, thumbnail: thumbnailBlob })
+        await db.put(record)
+
+        const result = await db.get(3000)
+        expect(result?.thumbnail).toBeInstanceOf(Blob)
+        expect(result?.thumbnail?.type).toBe('image/jpeg')
+        const text = await result!.thumbnail!.text()
+        expect(text).toBe('fake-jpeg')
+    })
+
+    it('stores record with null thumbnail', async () => {
+        const record = makeRecord({ recordedAt: 4000, thumbnail: null })
+        await db.put(record)
+
+        const result = await db.get(4000)
+        expect(result?.thumbnail).toBeNull()
+    })
+
+    it('returns undefined thumbnail for legacy records without thumbnail', async () => {
+        const record = makeRecord({ recordedAt: 5000 })
+        await db.put(record)
+
+        const result = await db.get(5000)
+        expect(result?.thumbnail).toBeUndefined()
+    })
+
     // ---- list ----
 
     it('list returns empty array when DB is empty', async () => {

--- a/tests/thumbnail.test.ts
+++ b/tests/thumbnail.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGetPrimaryVideoTrack = vi.fn()
+const mockGetFirstTimestamp = vi.fn()
+const mockGetSample = vi.fn()
+const mockInputDispose = vi.fn()
+const mockDrawWithFit = vi.fn()
+const mockConvertToBlob = vi.fn()
+const mockGetContext = vi.fn()
+const mockOffscreenCanvasConstructor = vi.fn()
+
+vi.mock('mediabunny', () => {
+    return {
+        ALL_FORMATS: ['webm', 'mp4'],
+        BlobSource: class MockBlobSource {},
+        Input: class MockInput {
+            getPrimaryVideoTrack = mockGetPrimaryVideoTrack;
+            [Symbol.dispose] = mockInputDispose
+        },
+        VideoSampleSink: class MockVideoSampleSink {
+            getSample = mockGetSample
+        },
+    }
+})
+
+import { generateThumbnail } from '../src/thumbnail'
+
+function createFakeSample() {
+    return {
+        [Symbol.dispose]: vi.fn(),
+        drawWithFit: mockDrawWithFit,
+    }
+}
+
+describe('generateThumbnail', () => {
+    beforeEach(() => {
+        mockGetPrimaryVideoTrack.mockReset()
+        mockGetFirstTimestamp.mockReset()
+        mockGetSample.mockReset()
+        mockInputDispose.mockReset()
+        mockDrawWithFit.mockReset()
+        mockConvertToBlob.mockReset()
+        mockGetContext.mockReset()
+        mockOffscreenCanvasConstructor.mockReset()
+
+        mockGetContext.mockReturnValue({})
+
+        vi.stubGlobal(
+            'OffscreenCanvas',
+            class MockOffscreenCanvas {
+                getContext = mockGetContext
+                convertToBlob = mockConvertToBlob
+                constructor(width: number, height: number) {
+                    mockOffscreenCanvasConstructor(width, height)
+                }
+            },
+        )
+    })
+
+    it('generates a WebP thumbnail from the first frame', async () => {
+        const fakeBlob = new Blob(['webp-data'], { type: 'image/webp' })
+        mockGetPrimaryVideoTrack.mockResolvedValue({
+            displayWidth: 1920,
+            displayHeight: 1080,
+            getFirstTimestamp: mockGetFirstTimestamp,
+        })
+        mockGetFirstTimestamp.mockResolvedValue(0.5)
+        mockGetSample.mockResolvedValue(createFakeSample())
+        mockConvertToBlob.mockResolvedValue(fakeBlob)
+
+        const videoBlob = new Blob(['video'], { type: 'video/webm' })
+        const result = await generateThumbnail(videoBlob)
+
+        expect(result).toBe(fakeBlob)
+        expect(mockGetSample).toHaveBeenCalledWith(0.5)
+        expect(mockOffscreenCanvasConstructor).toHaveBeenCalledWith(480, 270)
+        expect(mockConvertToBlob).toHaveBeenCalledWith({ type: 'image/webp', quality: 0.8 })
+        expect(mockInputDispose).toHaveBeenCalled()
+    })
+
+    it('uses custom width and calculates height from aspect ratio', async () => {
+        mockGetPrimaryVideoTrack.mockResolvedValue({
+            displayWidth: 1280,
+            displayHeight: 720,
+            getFirstTimestamp: mockGetFirstTimestamp,
+        })
+        mockGetFirstTimestamp.mockResolvedValue(0)
+        mockGetSample.mockResolvedValue(createFakeSample())
+        mockConvertToBlob.mockResolvedValue(new Blob())
+
+        await generateThumbnail(new Blob(), { width: 160 })
+
+        expect(mockOffscreenCanvasConstructor).toHaveBeenCalledWith(160, 90)
+    })
+
+    it('throws when no video track found', async () => {
+        mockGetPrimaryVideoTrack.mockResolvedValue(null)
+
+        await expect(generateThumbnail(new Blob())).rejects.toThrow('failed to get video track')
+        expect(mockInputDispose).toHaveBeenCalled()
+    })
+
+    it('throws when getPrimaryVideoTrack rejects', async () => {
+        mockGetPrimaryVideoTrack.mockRejectedValue(new Error('decode error'))
+
+        await expect(generateThumbnail(new Blob())).rejects.toThrow('decode error')
+        expect(mockInputDispose).toHaveBeenCalled()
+    })
+
+    it('throws when getSample rejects', async () => {
+        mockGetPrimaryVideoTrack.mockResolvedValue({
+            displayWidth: 1920,
+            displayHeight: 1080,
+            getFirstTimestamp: mockGetFirstTimestamp,
+        })
+        mockGetFirstTimestamp.mockResolvedValue(0)
+        mockGetSample.mockRejectedValue(new Error('sample error'))
+
+        await expect(generateThumbnail(new Blob())).rejects.toThrow('sample error')
+        expect(mockInputDispose).toHaveBeenCalled()
+    })
+
+    it('throws when getSample returns null', async () => {
+        mockGetPrimaryVideoTrack.mockResolvedValue({
+            displayWidth: 1920,
+            displayHeight: 1080,
+            getFirstTimestamp: mockGetFirstTimestamp,
+        })
+        mockGetFirstTimestamp.mockResolvedValue(0)
+        mockGetSample.mockResolvedValue(null)
+
+        await expect(generateThumbnail(new Blob())).rejects.toThrow('failed to get video frame')
+        expect(mockInputDispose).toHaveBeenCalled()
+    })
+
+    it('throws when getFirstTimestamp rejects', async () => {
+        mockGetPrimaryVideoTrack.mockResolvedValue({
+            displayWidth: 1920,
+            displayHeight: 1080,
+            getFirstTimestamp: vi.fn().mockRejectedValue(new Error('timestamp error')),
+        })
+
+        await expect(generateThumbnail(new Blob())).rejects.toThrow('timestamp error')
+        expect(mockInputDispose).toHaveBeenCalled()
+    })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,6 +33,16 @@ export default defineConfig(({ mode }) => ({
             output: {
                 entryFileNames: '[name].js',
                 chunkFileNames: '[name]-[hash].js',
+                codeSplitting: {
+                    minSize: 20000,
+                    groups: [
+                        {
+                            name: 'vendor-mediabunny',
+                            test: /node_modules[\\/]@mediabunny/,
+                            priority: 10,
+                        },
+                    ],
+                },
             },
         },
         sourcemap: !!process.env.SOURCEMAP,


### PR DESCRIPTION
This pull request introduces video thumbnail support for recordings, enhancing the user interface by displaying generated thumbnails in the recordings list. The main changes involve generating, storing, serving, and displaying WebP thumbnails for each video recording. Additionally, there are related UI improvements and minor theme adjustments.

**Video Thumbnail Generation and Storage**
- Added a new module `src/thumbnail.ts` that generates a WebP thumbnail from the first frame of a video using the `mediabunny` library. Thumbnails are generated after recording stops and stored in the IndexedDB record for each video. [[1]](diffhunk://#diff-e0b3af53e148eb420409477aff6fda535affd9dc6d1b839ae179e7724e00e142R1-R43) [[2]](diffhunk://#diff-2cd9574db7de00aeee9efe2ae07c8b53c29c954d46d5b9078efe3388cf8afaebR14) [[3]](diffhunk://#diff-2cd9574db7de00aeee9efe2ae07c8b53c29c954d46d5b9078efe3388cf8afaebR152-R163) [[4]](diffhunk://#diff-2cd9574db7de00aeee9efe2ae07c8b53c29c954d46d5b9078efe3388cf8afaebR175) [[5]](diffhunk://#diff-b8069b156a847fdfc042e2f9665ae575b5d3e52e1c1b9bacf1f44dcda126b8d8R46-R47) [[6]](diffhunk://#diff-2cd9574db7de00aeee9efe2ae07c8b53c29c954d46d5b9078efe3388cf8afaebR44) [[7]](diffhunk://#diff-7edf71b8e6c0fbe3e02537c2de10da15c14bba6f87c0e0251b1697a55456a454R70-R78)

**API and Backend Support**
- Updated the API handler to support serving thumbnail files at `/api/recordings/video-{timestamp}-thumbnail.webp`, returning the thumbnail blob from IndexedDB if available. [[1]](diffhunk://#diff-9b1c70fddbc960215ec54e116f57f4af1a5deb9d573fc6c4211f6afbd07c0f44R96) [[2]](diffhunk://#diff-9b1c70fddbc960215ec54e116f57f4af1a5deb9d573fc6c4211f6afbd07c0f44R203-R226) [[3]](diffhunk://#diff-9b1c70fddbc960215ec54e116f57f4af1a5deb9d573fc6c4211f6afbd07c0f44L264) [[4]](diffhunk://#diff-6574d92e81d76e13a2a51e190da4140d7f8b291d563d1cda91368de08ab641e9R10)

**UI Enhancements for Recordings List**
- Modified the recordings list (`src/element/recordList.ts`) to show a thumbnail next to each recording. If a thumbnail is missing or fails to load, a placeholder is displayed. The UI also shows a "Recording" badge for in-progress recordings. [[1]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3R50-R57) [[2]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3R97-R107) [[3]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3R141-R178) [[4]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3R294-R327) [[5]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3R345-R346) [[6]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L276-R358) [[7]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L286-R369) [[8]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3R387)

**Styling and Theme Adjustments**
- Added new CSS variables and styles for thumbnail containers and placeholders, including theme variants for both light and dark modes. Minor adjustments to container widths and input styles for consistency. [[1]](diffhunk://#diff-0e21fb1c9519a397050defc2148a2d1b966a0982cc4cf196e1e6b007f8d095e5R49) [[2]](diffhunk://#diff-0e21fb1c9519a397050defc2148a2d1b966a0982cc4cf196e1e6b007f8d095e5R82) [[3]](diffhunk://#diff-ef0273070ee7794f316f6e827eab760058134e7e5b6ea633654dc362f2a83e32L13-R13) [[4]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R101-R103) [[5]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R226)

These changes collectively improve the user experience by making it easier to visually identify recordings and providing a more polished interface.