### PR TITLE
fix: reduce cooldown periods for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 3
-      semver-major-days: 14
-      semver-minor-days: 5
-      semver-patch-days: 3
     groups:
       mediabunny:
         patterns:


### PR DESCRIPTION
This pull request makes a small update to the Dependabot configuration by removing the custom cooldown periods for major, minor, and patch semantic version updates. The configuration now only specifies the default cooldown period for all update types.

- Removed `semver-major-days`, `semver-minor-days`, and `semver-patch-days` cooldown settings from `.github/dependabot.yml`, so only the `default-days` cooldown applies to all dependency updates.