### PR TITLE
fix: Correction of FLAC encoder registration timing

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -7,22 +7,8 @@ import {
     QUALITY_HIGH,
     QUALITY_MEDIUM,
     QUALITY_LOW,
-    canEncodeAudio,
 } from 'mediabunny'
-import { registerFlacEncoder } from '@mediabunny/flac-encoder'
 import type { OutputFormat, Quality } from 'mediabunny'
-
-const isServiceWorker = typeof ServiceWorkerGlobalScope !== 'undefined' && self instanceof ServiceWorkerGlobalScope
-if (!isServiceWorker) {
-    // Register encoder polyfills if browser doesn't natively support them
-    canEncodeAudio('flac')
-        .then(supported => {
-            if (!supported) registerFlacEncoder()
-        })
-        .catch(e => {
-            console.error('failed to register flac encoder:', e)
-        })
-}
 
 export interface Resolution {
     width: number

--- a/src/element/settings.ts
+++ b/src/element/settings.ts
@@ -41,6 +41,7 @@ import Alert from './alert'
 import { applyTheme } from '../theme'
 import { t } from '../i18n'
 import { switchLabelStyle } from './switchStyle'
+import { registerFlacEncoder } from '@mediabunny/flac-encoder'
 
 @customElement('extension-settings')
 export class Settings extends LitElement {
@@ -182,6 +183,14 @@ export class Settings extends LitElement {
     }
 
     protected override async firstUpdated() {
+        try {
+            const isFLACSupported = await canEncodeAudio('flac')
+            if (!isFLACSupported) {
+                registerFlacEncoder()
+            }
+        } catch (error) {
+            console.error('Failed to initialize FLAC encoding support.', error)
+        }
         await this.validateEncoding()
     }
 

--- a/src/recorder/recorder.ts
+++ b/src/recorder/recorder.ts
@@ -1,4 +1,4 @@
-import type { Output } from 'mediabunny'
+import { canEncodeAudio, type Output } from 'mediabunny'
 import type { VideoFormat, CropRegion } from '../configuration'
 import { hasVideo, hasAudio } from '../configuration'
 import type { StartRecording, StartRecordingResponse } from '../message'
@@ -13,6 +13,7 @@ import type { FileManager } from './file_manager'
 import type { SubFileInfo } from '../recording_db'
 import { sendException } from '../sentry'
 import type { OffscreenSession } from '../offscreen_handler'
+import { registerFlacEncoder } from '@mediabunny/flac-encoder'
 
 export type RecorderState = 'idle' | 'starting' | 'recording' | 'paused'
 
@@ -79,6 +80,10 @@ export class RecordingSession implements OffscreenSession {
         try {
             const startAtMs = Date.now()
             const { videoFormat, recordingSize, microphone, cropping, muteRecordingTab, audioSeparation } = config
+
+            if (config.videoFormat.audioCodec === 'flac' && !(await canEncodeAudio('flac'))) {
+                registerFlacEncoder()
+            }
 
             // Prepare output file
             const fileHandle = await this.fileManager.createRecordingFile(startAtMs, videoFormat.container)


### PR DESCRIPTION
This pull request refactors how the FLAC audio encoder polyfill is registered, moving the logic from a global check in `src/configuration.ts` to more targeted, component-specific checks in `src/element/settings.ts` and `src/recorder/recorder.ts`. This makes the registration process more modular and ensures the encoder is only loaded when actually needed.

**Refactoring FLAC encoder registration:**

* Removed global FLAC encoder registration logic from `src/configuration.ts`, eliminating the check for FLAC support and the unconditional import of `registerFlacEncoder` at module load time.
* Added FLAC encoder registration to the `Settings` component in `src/element/settings.ts`, so the encoder is registered only if FLAC is not supported when the settings UI is first updated. [[1]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R44) [[2]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R186-R189)
* Added FLAC encoder registration to the recording logic in `src/recorder/recorder.ts`, ensuring the encoder is registered just before starting a recording session that requires FLAC, and only if FLAC is not natively supported. [[1]](diffhunk://#diff-317e957cd212346e2ef66f5864b27c77a911e018cb808f4787b7078a9ce19ba4L1-R1) [[2]](diffhunk://#diff-317e957cd212346e2ef66f5864b27c77a911e018cb808f4787b7078a9ce19ba4R16) [[3]](diffhunk://#diff-317e957cd212346e2ef66f5864b27c77a911e018cb808f4787b7078a9ce19ba4R75-R78)