### PR TITLE
fix: recording error handling

### DIFF
--- a/src/element/alert.ts
+++ b/src/element/alert.ts
@@ -8,8 +8,13 @@ import { t } from '../i18n'
 export default class Alert extends LitElement {
     static override readonly styles = css`
         md-dialog {
-            width: 520px;
+            width: 600px;
             --md-dialog-container-color: var(--theme-dialog-bg, var(--md-sys-color-surface-container-high));
+        }
+        pre {
+            overflow-x: scroll;
+            margin: 0;
+            font-size: 0.8rem;
         }
     `
 
@@ -18,6 +23,9 @@ export default class Alert extends LitElement {
 
     @property({ noAccessor: true })
     private content: string = ''
+
+    @property({ noAccessor: true })
+    private preformatted: boolean = false
 
     public constructor() {
         super()
@@ -28,7 +36,9 @@ export default class Alert extends LitElement {
             <md-dialog>
                 <div slot="headline">${this.headline}</div>
                 <form id="form" slot="content" method="dialog">
-                    ${this.content.split('\n').map(p => html`<p>${p}</p>`)}
+                    ${this.preformatted
+                        ? html`<pre>${this.content}</pre>`
+                        : this.content.split('\n').map(p => html`<p>${p}</p>`)}
                 </form>
                 <div slot="actions">
                     <md-text-button form="form" value="ok" autofocus>${t('alertOk')}</md-text-button>
@@ -37,13 +47,16 @@ export default class Alert extends LitElement {
         `
     }
 
-    public setContent(headline: string, content: string) {
+    public setContent(headline: string, content: string, options?: { preformatted?: boolean }) {
         const oldHeadline = this.headline
         this.headline = headline
         this.requestUpdate('headline', oldHeadline)
         const oldContent = this.content
         this.content = content
         this.requestUpdate('content', oldContent)
+        const oldPreformatted = this.preformatted
+        this.preformatted = options?.preformatted ?? false
+        this.requestUpdate('preformatted', oldPreformatted)
     }
 }
 

--- a/src/element/confirm.ts
+++ b/src/element/confirm.ts
@@ -15,7 +15,7 @@ import { t } from '../i18n'
 export default class Confirm extends LitElement {
     static override readonly styles = css`
         md-dialog {
-            width: 520px;
+            width: 600px;
             --md-dialog-container-color: var(--theme-dialog-bg, var(--md-sys-color-surface-container-high));
             --md-text-button-label-text-color: var(--theme-error, #f44336);
             --md-text-button-focus-label-text-color: var(--theme-error, #f44336);

--- a/src/element/recordList.ts
+++ b/src/element/recordList.ts
@@ -282,7 +282,7 @@ export class RecordList extends LitElement {
     private static showRecordingError(error: string) {
         const alertDialog = document.getElementById('alert-dialog') as Alert | null
         if (alertDialog == null) return
-        alertDialog.setContent(t('recordListRecordingFailed'), error)
+        alertDialog.setContent(t('recordListRecordingFailed'), error, { preformatted: true })
         const dialog = alertDialog.shadowRoot?.querySelector('md-dialog') as MdDialog | null
         dialog?.show()
     }

--- a/src/element/timerStopConfirm.ts
+++ b/src/element/timerStopConfirm.ts
@@ -17,7 +17,7 @@ import { t } from '../i18n'
 export default class TimerStopConfirm extends LitElement {
     static override readonly styles = css`
         md-dialog {
-            width: 520px;
+            width: 600px;
             --md-dialog-container-color: var(--theme-dialog-bg, var(--md-sys-color-surface-container-high));
         }
         .checkbox-row {

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,8 @@
+export function errorToString(e: unknown): string {
+    if (!(e instanceof Error)) return String(e)
+    let msg = (e.stack ?? String(e)).replaceAll(/chrome-extension:\/\/[a-p]+\//g, '')
+    if (e.cause) {
+        msg += '\nCaused by: ' + errorToString(e.cause)
+    }
+    return msg
+}

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -13,6 +13,7 @@ import { Crop } from './crop'
 import { createRecordingSession } from './recorder'
 import { OffscreenHandler } from './offscreen_handler'
 import { RecordingDB } from './recording_db'
+import { errorToString } from './error'
 
 const preview = new Preview(async ({ image, width, height }) => {
     const msg: PreviewFrameMessage = {
@@ -36,7 +37,7 @@ const session = createRecordingSession(preview, crop, {
     },
     onSourceError: async (e: Error) => {
         sendException(e, { exceptionSource: 'offscreen.startRecording' })
-        const msg: UnexpectedRecordingStateMessage = { type: 'unexpected-recording-state', error: e.message }
+        const msg: UnexpectedRecordingStateMessage = { type: 'unexpected-recording-state', error: errorToString(e) }
         try {
             await chrome.runtime.sendMessage(msg)
         } catch (sendErr) {

--- a/src/recorder/audio_separation.ts
+++ b/src/recorder/audio_separation.ts
@@ -12,7 +12,7 @@ export interface AudioSeparationOutputs {
     sources: PausableSource[]
     /** Cloned media tracks that must be stopped on cleanup */
     clonedTracks: MediaStreamTrack[]
-    /** Error promises from audio track sources (for logging, non-fatal) */
+    /** Error promises from audio track sources */
     errorPromises: Promise<void>[]
     /** File handles for retrieving sub-file info after finalize */
     tabFileHandle?: FileSystemFileHandle

--- a/src/recorder/output_manager.ts
+++ b/src/recorder/output_manager.ts
@@ -47,8 +47,7 @@ export class OutputManager {
                 sources.push(videoSource)
                 errorPromises.push(
                     videoSource.errorPromise.catch(e => {
-                        console.error('Video source error:', e)
-                        throw e
+                        throw new Error('Video source error', { cause: e })
                     }),
                 )
             }
@@ -66,8 +65,7 @@ export class OutputManager {
                 sources.push(audioSource)
                 errorPromises.push(
                     audioSource.errorPromise.catch(e => {
-                        console.error('Audio source error:', e)
-                        throw e
+                        throw new Error('Audio source error', { cause: e })
                     }),
                 )
             }
@@ -96,7 +94,11 @@ export class OutputManager {
         return {
             output,
             sources: [audioSource],
-            errorPromises: [audioSource.errorPromise],
+            errorPromises: [
+                audioSource.errorPromise.catch(e => {
+                    throw new Error('Audio separation source error', { cause: e })
+                }),
+            ],
         }
     }
 }

--- a/src/recorder/recorder.ts
+++ b/src/recorder/recorder.ts
@@ -142,36 +142,22 @@ export class RecordingSession implements OffscreenSession {
 
             // Audio separation
             if (audioSeparation.enabled) {
-                try {
-                    this.separationOutputs = await this.audioSeparation.createOutputs(
-                        startAtMs,
-                        tabMedia,
-                        micStream,
-                        videoFormat,
-                    )
-                    this.mediaTracks.push(...this.separationOutputs.clonedTracks)
-                    this.allSources.push(...this.separationOutputs.sources)
-                    // Report first separation error to Sentry (non-fatal)
-                    Promise.all(this.separationOutputs.errorPromises).catch(e => {
-                        console.error('Audio separation source error:', e)
-                        sendException(e, { exceptionSource: 'recorder.audioSeparationSource' })
-                    })
-                } catch (e) {
-                    console.error('Failed to create audio separation outputs:', e)
-                    sendException(e, { exceptionSource: 'recorder.createAudioSeparation' })
-                    // Non-fatal: continue without separation
-                }
+                this.separationOutputs = await this.audioSeparation.createOutputs(
+                    startAtMs,
+                    tabMedia,
+                    micStream,
+                    videoFormat,
+                )
+                this.mediaTracks.push(...this.separationOutputs.clonedTracks)
+                this.allSources.push(...this.separationOutputs.sources)
+                errorPromises.push(...this.separationOutputs.errorPromises)
             }
 
             // Handle media source errors
-            Promise.all(errorPromises)
-                .catch(async e => {
-                    await this.callbacks.onSourceError(e instanceof Error ? e : new Error(String(e)))
-                })
-                .catch(e => {
-                    console.error(e)
-                    sendException(e, { exceptionSource: 'recorder.sourceErrorCallback' })
-                })
+            Promise.all(errorPromises).catch(async e => {
+                console.error(e)
+                await this.callbacks.onSourceError(e instanceof Error ? e : new Error(String(e)))
+            })
 
             // Start outputs
             this.recordingStartTime = startAtMs

--- a/tests/error.test.ts
+++ b/tests/error.test.ts
@@ -1,0 +1,37 @@
+import { errorToString } from '../src/error'
+
+describe('errorToString', () => {
+    it('returns stringified non-Error values', () => {
+        expect(errorToString('plain error')).toBe('plain error')
+    })
+
+    it('removes chrome extension URLs from the stack trace', () => {
+        const error = new Error('boom')
+        error.stack = [
+            'Error: boom',
+            '    at start (chrome-extension://abcdefghijklmnop/src/offscreen.ts:10:5)',
+            '    at next (chrome-extension://ponmlkjihgfedcba/src/other.ts:20:8)',
+        ].join('\n')
+
+        expect(errorToString(error)).toBe(
+            ['Error: boom', '    at start (src/offscreen.ts:10:5)', '    at next (src/other.ts:20:8)'].join('\n'),
+        )
+    })
+
+    it('includes nested causes recursively', () => {
+        const rootCause = new Error('root cause')
+        rootCause.stack = 'Error: root cause\n    at leaf (src/leaf.ts:3:1)'
+
+        const error = new Error('top level', { cause: rootCause })
+        error.stack = 'Error: top level\n    at main (src/main.ts:1:1)'
+
+        expect(errorToString(error)).toBe(
+            [
+                'Error: top level',
+                '    at main (src/main.ts:1:1)',
+                'Caused by: Error: root cause',
+                '    at leaf (src/leaf.ts:3:1)',
+            ].join('\n'),
+        )
+    })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,7 +38,12 @@ export default defineConfig(({ mode }) => ({
                     groups: [
                         {
                             name: 'vendor-mediabunny',
-                            test: /node_modules[\\/]@mediabunny/,
+                            test: /node_modules[\\/]mediabunny/,
+                            priority: 20,
+                        },
+                        {
+                            name: 'vendor-mediabunny-flac-encoder',
+                            test: /node_modules[\\/]@mediabunny[\\/]flac-encoder/,
                             priority: 10,
                         },
                     ],


### PR DESCRIPTION
This pull request introduces improvements to error handling, alert dialog flexibility, and minor UI adjustments. The most significant changes include the introduction of a utility for formatting errors (with stack trace cleanup and cause chaining), improved error propagation in media source handling, and enhancements to the alert dialog component to support preformatted content. Additionally, there are minor updates to dialog widths and Vite config chunking.

**Error handling improvements:**

* Added a new `errorToString` utility in `src/error.ts` that formats errors by removing Chrome extension URLs from stack traces and recursively including causes; includes unit tests in `tests/error.test.ts` [[1]](diffhunk://#diff-39f1e030815f30ed52f7f86a69761ef60e22bbfd1521ac8d065e6d86a4bc8337R1-R8) [[2]](diffhunk://#diff-f0bec588e27ffff81c0052a6cfa938298d82fa99d058ab2381980d02fa4fcb2fR1-R37).
* Updated error propagation in `src/recorder/output_manager.ts` and `src/recorder/recorder.ts` to wrap errors with context using the `cause` property and to aggregate error promises for unified handling [[1]](diffhunk://#diff-d01cf29b87adcaef4dd7fb08ef7d504d794151f539bfe2a10ef545812752c501L50-R50) [[2]](diffhunk://#diff-d01cf29b87adcaef4dd7fb08ef7d504d794151f539bfe2a10ef545812752c501L69-R68) [[3]](diffhunk://#diff-d01cf29b87adcaef4dd7fb08ef7d504d794151f539bfe2a10ef545812752c501L99-R101) [[4]](diffhunk://#diff-317e957cd212346e2ef66f5864b27c77a911e018cb808f4787b7078a9ce19ba4L145) [[5]](diffhunk://#diff-317e957cd212346e2ef66f5864b27c77a911e018cb808f4787b7078a9ce19ba4L154-R159).
* Changed offscreen error reporting to use the new `errorToString` utility for more informative error messages [[1]](diffhunk://#diff-7edf71b8e6c0fbe3e02537c2de10da15c14bba6f87c0e0251b1697a55456a454R16) [[2]](diffhunk://#diff-7edf71b8e6c0fbe3e02537c2de10da15c14bba6f87c0e0251b1697a55456a454L39-R40).

**Alert dialog enhancements:**

* Updated `Alert` component in `src/element/alert.ts` to support a `preformatted` option, allowing display of preformatted error messages [[1]](diffhunk://#diff-2f68eaaeb46efb8f5bf3ec8270117aa65e3603aa74477605350daecb5b70f0f4L11-R18) [[2]](diffhunk://#diff-2f68eaaeb46efb8f5bf3ec8270117aa65e3603aa74477605350daecb5b70f0f4R27-R29) [[3]](diffhunk://#diff-2f68eaaeb46efb8f5bf3ec8270117aa65e3603aa74477605350daecb5b70f0f4L31-R41) [[4]](diffhunk://#diff-2f68eaaeb46efb8f5bf3ec8270117aa65e3603aa74477605350daecb5b70f0f4L40-R59).
* Modified usage in `src/element/recordList.ts` to show recording errors as preformatted text for better readability.

**UI and configuration adjustments:**

* Increased dialog widths from 520px to 600px in `src/element/alert.ts`, `src/element/confirm.ts`, and `src/element/timerStopConfirm.ts` for improved appearance [[1]](diffhunk://#diff-2f68eaaeb46efb8f5bf3ec8270117aa65e3603aa74477605350daecb5b70f0f4L11-R18) [[2]](diffhunk://#diff-80da059d13546819162c9cc43b951d248ce7418574fbf0e24f45fa0bb52f645eL18-R18) [[3]](diffhunk://#diff-8e42f9c6cc541a03f149e768e4951633c0789513b134eca99fdaa91f7204bfadL20-R20).
* Updated Vite chunk splitting rules to separate `mediabunny` and `@mediabunny/flac-encoder` dependencies for optimized builds.

**Documentation and comments:**

* Clarified comment in `src/recorder/audio_separation.ts` regarding the purpose of `errorPromises`.