### PR TITLE
bump: v1.7.0

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,7 @@
     "short_name": "__MSG_appShortName__",
     "description": "__MSG_appDescription__",
     "default_locale": "en",
-    "version": "1.6.2",
+    "version": "1.7.0",
     "minimum_chrome_version": "140",
     "icons": {
         "16": "icons/icon16.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instant-tab-recorder",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instant-tab-recorder",
-      "version": "1.6.2",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@material/web": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instant-tab-recorder",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "type": "module",
   "description": "Google Chrome Extensions Screen Recorder",
   "scripts": {


### PR DESCRIPTION
This pull request updates the version number of the project from 1.6.2 to 1.7.0 in both the Chrome extension manifest and the main `package.json` file to prepare for a new release.

Version bump:

* Updated the `version` field in `extension/manifest.json` from 1.6.2 to 1.7.0.
* Updated the `version` field in `package.json` from 1.6.2 to 1.7.0.