### PR TITLE
fix: Update uiLanguage for plural rules

### DIFF
--- a/src/element/recordList.ts
+++ b/src/element/recordList.ts
@@ -180,7 +180,7 @@ export class RecordList extends LitElement {
         second: '2-digit',
     })
 
-    private static readonly uiLanguage = chrome?.i18n?.getMessage?.('@@ui_locale') || 'en'
+    private static readonly uiLanguage = chrome?.i18n?.getMessage?.('@@ui_locale')?.startsWith?.('ja') ? 'ja' : 'en'
     private static readonly pluralRules = new Intl.PluralRules(RecordList.uiLanguage)
     private static formatRecordCount(count: number): string {
         const category = RecordList.pluralRules.select(count)

--- a/tests/element/recordList.locale-en.test.ts
+++ b/tests/element/recordList.locale-en.test.ts
@@ -1,0 +1,100 @@
+import { render } from 'vitest-browser-lit'
+import { html } from 'lit'
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { shadowQuery, elementUpdated } from './test-helpers'
+import { getChromeMock } from './test-setup'
+import { mockGetMessage } from '../i18n-mock'
+
+// Mock dependencies
+const listRecordingsMock = vi.fn().mockResolvedValue([])
+vi.mock('../../src/api_client', () => ({
+    recordingApi: {
+        listRecordings: (...args: unknown[]) => listRecordingsMock(...args),
+        getRecordingFile: vi.fn().mockResolvedValue(null),
+        deleteRecording: vi.fn().mockResolvedValue(undefined),
+        getStorageEstimate: vi.fn().mockResolvedValue({ usage: 0, quota: 1073741824 }),
+    },
+}))
+vi.mock('../../src/sentry', () => ({
+    sendException: vi.fn(),
+    sendFeedback: vi.fn(),
+    sendEvent: vi.fn(),
+}))
+
+// Override chrome mock to return 'en_US' for @@ui_locale BEFORE importing recordList
+const chromeMock = getChromeMock()
+chromeMock.i18n.getMessage.mockImplementation((key: string, subs?: string | string[]) => {
+    if (key === '@@ui_locale') return 'en_US'
+    return mockGetMessage(key, subs)
+})
+
+// Dynamic import AFTER mock is configured so uiLanguage evaluates as 'en'
+await import('../../src/element/recordList')
+
+describe('record-list locale: en_US', () => {
+    beforeEach(() => {
+        listRecordingsMock.mockReset().mockResolvedValue([])
+    })
+
+    test('English pluralRules selects "one" for count=1 (singular)', async () => {
+        listRecordingsMock.mockResolvedValue([
+            {
+                title: 'video-1000000000000.webm',
+                path: 'video-1000000000000.webm',
+                size: 1024,
+                lastModified: Date.now(),
+                mimeType: 'video/webm',
+                recordedAt: 1000000000000,
+                isTemporary: false,
+                subFiles: [],
+                subFilesSize: 0,
+            },
+        ])
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const heading = shadowQuery(el, '.storage-heading')
+            // English plural: count=1 → 'one' category → "1 Record" (singular)
+            expect(heading?.textContent).toContain('1 Record')
+            expect(heading?.textContent).not.toContain('1 Records')
+        })
+    })
+
+    test('English pluralRules selects "other" for count=0 (plural)', async () => {
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const heading = shadowQuery(el, '.storage-heading')
+            expect(heading?.textContent).toContain('0 Records')
+        })
+    })
+
+    test('English pluralRules selects "other" for count=2+ (plural)', async () => {
+        const recordings = Array.from({ length: 2 }, (_, i) => ({
+            title: `video-${1000000000000 + i * 1000}.webm`,
+            path: `video-${1000000000000 + i * 1000}.webm`,
+            size: 512,
+            lastModified: Date.now(),
+            mimeType: 'video/webm',
+            recordedAt: 1000000000000 + i * 1000,
+            isTemporary: false,
+            subFiles: [],
+            subFilesSize: 0,
+        }))
+        listRecordingsMock.mockResolvedValue(recordings)
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const heading = shadowQuery(el, '.storage-heading')
+            expect(heading?.textContent).toContain('2 Records')
+        })
+    })
+})

--- a/tests/element/recordList.locale-ja.test.ts
+++ b/tests/element/recordList.locale-ja.test.ts
@@ -1,0 +1,125 @@
+import { render } from 'vitest-browser-lit'
+import { html } from 'lit'
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { shadowQuery, elementUpdated } from './test-helpers'
+import { getChromeMock } from './test-setup'
+import jaMessages from '../../extension/_locales/ja/messages.json'
+
+type MessageEntry = { message: string; placeholders?: Record<string, { content: string }> }
+const messages = jaMessages as Record<string, MessageEntry>
+
+function mockGetMessageJa(key: string, substitutions?: string | string[]): string {
+    const entry = messages[key]
+    if (!entry) return ''
+    let result = entry.message
+    if (substitutions != null) {
+        const subs = Array.isArray(substitutions) ? substitutions : [substitutions]
+        for (let i = 0; i < subs.length; i++) {
+            result = result.replace(new RegExp(`\\$${i + 1}\\$`, 'g'), () => subs[i])
+        }
+        if (entry.placeholders) {
+            for (const [name, ph] of Object.entries(entry.placeholders)) {
+                const idx = parseInt(ph.content.replace(/\$/g, ''), 10) - 1
+                if (idx >= 0 && idx < subs.length) {
+                    result = result.replace(new RegExp(`\\$${name}\\$`, 'gi'), () => subs[idx])
+                }
+            }
+        }
+    }
+    return result
+}
+
+// Mock dependencies
+const listRecordingsMock = vi.fn().mockResolvedValue([])
+vi.mock('../../src/api_client', () => ({
+    recordingApi: {
+        listRecordings: (...args: unknown[]) => listRecordingsMock(...args),
+        getRecordingFile: vi.fn().mockResolvedValue(null),
+        deleteRecording: vi.fn().mockResolvedValue(undefined),
+        getStorageEstimate: vi.fn().mockResolvedValue({ usage: 0, quota: 1073741824 }),
+    },
+}))
+vi.mock('../../src/sentry', () => ({
+    sendException: vi.fn(),
+    sendFeedback: vi.fn(),
+    sendEvent: vi.fn(),
+}))
+
+// Override chrome mock to return 'ja' for @@ui_locale and use Japanese messages
+const chromeMock = getChromeMock()
+chromeMock.i18n.getMessage.mockImplementation((key: string, subs?: string | string[]) => {
+    if (key === '@@ui_locale') return 'ja'
+    return mockGetMessageJa(key, subs)
+})
+
+// Dynamic import AFTER mock is configured so uiLanguage evaluates as 'ja'
+await import('../../src/element/recordList')
+
+describe('record-list locale: ja', () => {
+    beforeEach(() => {
+        listRecordingsMock.mockReset().mockResolvedValue([])
+    })
+
+    test('Japanese pluralRules selects "other" for count=1 (no singular in Japanese)', async () => {
+        // In Japanese, Intl.PluralRules always returns 'other' for any number,
+        // so formatRecordCount(1) should use 'recordListRecordCountOther' → "1 件"
+        listRecordingsMock.mockResolvedValue([
+            {
+                title: 'video-1000000000000.webm',
+                path: 'video-1000000000000.webm',
+                size: 1024,
+                lastModified: Date.now(),
+                mimeType: 'video/webm',
+                recordedAt: 1000000000000,
+                isTemporary: false,
+                subFiles: [],
+                subFilesSize: 0,
+            },
+        ])
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const heading = shadowQuery(el, '.storage-heading')
+            // Japanese plural: count=1 → 'other' category → "1 件"
+            expect(heading?.textContent).toContain('1 件')
+        })
+    })
+
+    test('Japanese pluralRules selects "other" for count=0', async () => {
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const heading = shadowQuery(el, '.storage-heading')
+            expect(heading?.textContent).toContain('0 件')
+        })
+    })
+
+    test('Japanese pluralRules selects "other" for count=5', async () => {
+        const recordings = Array.from({ length: 5 }, (_, i) => ({
+            title: `video-${1000000000000 + i * 1000}.webm`,
+            path: `video-${1000000000000 + i * 1000}.webm`,
+            size: 512,
+            lastModified: Date.now(),
+            mimeType: 'video/webm',
+            recordedAt: 1000000000000 + i * 1000,
+            isTemporary: false,
+            subFiles: [],
+            subFilesSize: 0,
+        }))
+        listRecordingsMock.mockResolvedValue(recordings)
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const heading = shadowQuery(el, '.storage-heading')
+            expect(heading?.textContent).toContain('5 件')
+        })
+    })
+})

--- a/tests/element/recordList.test.ts
+++ b/tests/element/recordList.test.ts
@@ -279,6 +279,80 @@ describe('record-list', () => {
         })
     })
 
+    test('uiLanguage defaults to en when @@ui_locale does not start with ja', async () => {
+        // The chrome mock returns '' for @@ui_locale (not in messages.json),
+        // so uiLanguage resolves to 'en'. Verify English plural rules are applied:
+        // In English, count=1 → singular, count≠1 → plural.
+        listRecordingsMock.mockResolvedValue([
+            {
+                title: 'video-1000000000000.webm',
+                size: 512,
+                lastModified: Date.now(),
+                mimeType: 'video/webm',
+                recordedAt: 1000000000000,
+                isTemporary: false,
+                subFiles: [],
+                subFilesSize: 0,
+            },
+        ])
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        // English pluralization: 1 → "1 Record" (singular)
+        await vi.waitFor(() => {
+            const heading = shadowQuery(el, '.storage-heading')
+            expect(heading?.textContent).toContain('1 Record')
+            expect(heading?.textContent).not.toContain('1 Records')
+        })
+    })
+
+    test('pluralRules uses English rules: "one" for 1, "other" for 0 and 2+', () => {
+        // Intl.PluralRules('en') should select 'one' for 1 and 'other' for anything else
+        const rules = new Intl.PluralRules('en')
+        expect(rules.select(0)).toBe('other')
+        expect(rules.select(1)).toBe('one')
+        expect(rules.select(2)).toBe('other')
+        expect(rules.select(10)).toBe('other')
+    })
+
+    test('formatRecordCount uses plural form for 0 records', async () => {
+        listRecordingsMock.mockResolvedValue([])
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const heading = shadowQuery(el, '.storage-heading')
+            expect(heading?.textContent).toContain('0 Records')
+        })
+    })
+
+    test('formatRecordCount uses plural form for multiple records', async () => {
+        const recordings = Array.from({ length: 3 }, (_, i) => ({
+            title: `video-${1000000000000 + i * 1000}.webm`,
+            size: 1024,
+            lastModified: Date.now(),
+            mimeType: 'video/webm',
+            recordedAt: 1000000000000 + i * 1000,
+            isTemporary: false,
+            subFiles: [],
+            subFilesSize: 0,
+        }))
+        listRecordingsMock.mockResolvedValue(recordings)
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const heading = shadowQuery(el, '.storage-heading')
+            expect(heading?.textContent).toContain('3 Records')
+        })
+    })
+
     test('storage heading shows sum of record sizes including subFilesSize', async () => {
         const ts1 = '1000000000000'
         const ts2 = '1000000001000'


### PR DESCRIPTION
This pull request improves the handling and testing of pluralization and locale detection in the `record-list` component, ensuring that the correct plural rules are applied based on the user's UI language (English or Japanese). It also introduces comprehensive tests to verify pluralization logic for both locales and the fallback behavior.

**Locale detection and pluralization logic:**

* Updated the `uiLanguage` static property in `recordList.ts` to detect if the UI locale starts with `'ja'` and use `'ja'` for Japanese, otherwise defaulting to `'en'`. This change ensures correct pluralization rules for English and Japanese users.

**Testing improvements:**

* Added a new test suite `recordList.locale-en.test.ts` to verify that English pluralization is applied correctly for counts of 0, 1, and 2+, ensuring singular and plural forms are rendered as expected.
* Added a new test suite `recordList.locale-ja.test.ts` to verify that Japanese pluralization (which always returns 'other') is applied for all counts, ensuring the correct label is used for Japanese users.
* Enhanced the main `recordList.test.ts` with tests to confirm that English is used as the default locale when the UI locale is missing or not Japanese, and to directly test the plural rules and formatting logic for various record counts.