### PR TITLE
fix: Add default font variables to options stylesheet

### DIFF
--- a/extension/option.html
+++ b/extension/option.html
@@ -5,6 +5,11 @@
     <title>Options</title>
     <link href="material-symbols-outlined.css" rel="stylesheet">
     <style>
+        :root {
+            --md-ref-typeface-brand: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            --md-ref-typeface-plain: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        }
+
         body {
             margin-top: 0;
         }


### PR DESCRIPTION
This pull request makes a minor improvement to the `extension/option.html` file by defining CSS variables for the brand and plain typefaces. This change helps ensure consistent font usage across the extension's UI.

- UI consistency:
  * Added `--md-ref-typeface-brand` and `--md-ref-typeface-plain` CSS variables to the `:root` selector for standardized font usage.

https://material-web.dev/theming/typography/