### PR TITLE
fix: downgrade mediabunny dependencies to version 1.41.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@material/web": "^2.4.1",
-        "@mediabunny/flac-encoder": "^1.43.1",
+        "@mediabunny/flac-encoder": "1.41.0",
         "@sentry/browser": "^10.51.0",
         "lit": "^3.3.2",
-        "mediabunny": "^1.43.1",
+        "mediabunny": "1.41.0",
         "uuid": "^14.0.0"
       },
       "devDependencies": {
@@ -208,9 +208,9 @@
       }
     },
     "node_modules/@mediabunny/flac-encoder": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/@mediabunny/flac-encoder/-/flac-encoder-1.43.1.tgz",
-      "integrity": "sha512-xhzj182KUdjVg7gBxOBA9kZNx1ZTtlTRo+I4bGYx7/XIYwPYdjd76Vn6lOoHL0Acax/FxIJpHySODlsB2AgYLA==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/@mediabunny/flac-encoder/-/flac-encoder-1.41.0.tgz",
+      "integrity": "sha512-/XxTR5OwysnOQD6fg3smuQ2Ugkzb9qWfoaBLNUc/h5nOEmxwcgH1CIwK/G5XIrOBfGLqySFoYTJPlnl1whmk5Q==",
       "license": "MPL-2.0",
       "funding": {
         "type": "individual",
@@ -2463,9 +2463,9 @@
       }
     },
     "node_modules/mediabunny": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.43.1.tgz",
-      "integrity": "sha512-TuxRDvj2FrQjVZ5Zi1nNJ2NcpRbbc3FpDpNcwWAygeA4ND9w1xICOXnze8XUk0VlFhAMkQPm5Gy+yZL+BJ/Gtg==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.41.0.tgz",
+      "integrity": "sha512-cJWBHvAyRNgTbsx8Z2oHptX/PdiywwsS+GIvv2k9eioXSOzzAemBsHwf7jM6fvW3b65azvZGP9RLuO1DI8JmdA==",
       "license": "MPL-2.0",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   "license": "MIT",
   "dependencies": {
     "@material/web": "^2.4.1",
-    "@mediabunny/flac-encoder": "^1.43.1",
+    "@mediabunny/flac-encoder": "1.41.0",
     "@sentry/browser": "^10.51.0",
     "lit": "^3.3.2",
-    "mediabunny": "^1.43.1",
+    "mediabunny": "1.41.0",
     "uuid": "^14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
A regression occurred due to a dependent library, so the library in question will be downgraded.

```
Error: Audio source error
    at dist/offscreen.js:1:4514
    at async Promise.all (index 0)
Caused by: Error: Timestamps must be non-negative (got -0.000007517006451962516s).
    at lu.validateAndNormalizeTimestamp (dist/vendor-mediabunny-D1wOJfUE.js:24:13768)
    at lu.addEncodedAudioPacket (dist/vendor-mediabunny-D1wOJfUE.js:24:78907)
```

```
Error: Audio separation source error
    at dist/offscreen.js:1:4785
    at async Promise.all (index 2)
Caused by: Error: Timestamps must be non-negative (got -0.000008564625659346348s).
    at du.validateAndNormalizeTimestamp (dist/vendor-mediabunny-D1wOJfUE.js:24:13768)
    at du.addEncodedAudioPacket (dist/vendor-mediabunny-D1wOJfUE.js:24:87229)
```