### PR TITLE
fix: handle thumbnail generation errors with NoVideoError

### DIFF
--- a/src/offscreen_handler.ts
+++ b/src/offscreen_handler.ts
@@ -11,7 +11,7 @@ import type {
 import type { RecordingConfig, RecordingResult } from './recorder'
 import type { Event, ExceptionMetadata } from './sentry_event'
 import type { RecordingDB, RecordingRecord } from './recording_db'
-import { generateThumbnail } from './thumbnail'
+import { generateThumbnail, NoVideoError } from './thumbnail'
 
 // ---------- dependency interfaces ----------
 
@@ -155,8 +155,10 @@ export class OffscreenHandler {
                     const videoFile = await this.deps.getVideoFile(result.mainFilePath)
                     thumbnail = await generateThumbnail(videoFile)
                 } catch (e) {
-                    console.error('Failed to generate thumbnail:', e)
-                    this.deps.sendException(e, { exceptionSource: 'offscreen.stopRecording.thumbnail' })
+                    if (!(e instanceof NoVideoError)) {
+                        console.error('Failed to generate thumbnail:', e)
+                        this.deps.sendException(e, { exceptionSource: 'offscreen.stopRecording.thumbnail' })
+                    }
                 }
 
                 // Update IndexedDB record with final metadata

--- a/src/thumbnail.ts
+++ b/src/thumbnail.ts
@@ -3,6 +3,13 @@ import { ALL_FORMATS, BlobSource, Input, VideoSampleSink } from 'mediabunny'
 const DEFAULT_WIDTH = 480
 const QUALITY = 0.8
 
+export class NoVideoError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'NoVideoError'
+    }
+}
+
 /**
  * Generate a WebP thumbnail from the first frame of a video blob.
  * Throws if thumbnail generation fails.
@@ -13,7 +20,7 @@ export async function generateThumbnail(videoBlob: Blob, options?: { width?: num
         source: new BlobSource(videoBlob),
     })
     const videoTrack = await input.getPrimaryVideoTrack()
-    if (!videoTrack) throw new Error('failed to get video track')
+    if (!videoTrack) throw new NoVideoError('failed to get video track')
 
     const firstTimestamp = await videoTrack.getFirstTimestamp()
     const sink = new VideoSampleSink(videoTrack)

--- a/tests/offscreen_handler.test.ts
+++ b/tests/offscreen_handler.test.ts
@@ -8,12 +8,22 @@ vi.mock('@mediabunny/flac-encoder', () => ({
 }))
 
 const generateThumbnailMock = vi.fn().mockResolvedValue(null)
-vi.mock('../src/thumbnail', () => ({
-    generateThumbnail: (...args: unknown[]) => generateThumbnailMock(...args),
-}))
+vi.mock('../src/thumbnail', () => {
+    class NoVideoError extends Error {
+        constructor(message: string) {
+            super(message)
+            this.name = 'NoVideoError'
+        }
+    }
+    return {
+        generateThumbnail: (...args: unknown[]) => generateThumbnailMock(...args),
+        NoVideoError,
+    }
+})
 
 import { OffscreenHandler } from '../src/offscreen_handler'
 import type { OffscreenDeps, OffscreenSession } from '../src/offscreen_handler'
+import { NoVideoError } from '../src/thumbnail'
 import type { Message, StartRecordingResponse } from '../src/message'
 import { Configuration, VideoFormat } from '../src/configuration'
 import type { RecordingDB } from '../src/recording_db'
@@ -434,16 +444,23 @@ describe('stop-recording', () => {
         expect(deps.recordingDB.put).toHaveBeenCalledWith(expect.objectContaining({ thumbnail: null }))
     })
 
-    it('stores null thumbnail when generateThumbnail returns null', async () => {
-        const fakeVideoFile = new Blob(['video-data'], { type: 'video/webm' })
-        generateThumbnailMock.mockResolvedValue(null)
-        const deps = createMockDeps({
-            getVideoFile: vi.fn().mockResolvedValue(fakeVideoFile),
-        })
-        const handler = new OffscreenHandler(deps)
-        await handler.handleMessage({ type: 'stop-recording', trigger: 'action-icon' })
+    it('suppresses NoVideoError without sending exception or logging', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        try {
+            const fakeVideoFile = new Blob(['video-data'], { type: 'video/webm' })
+            generateThumbnailMock.mockRejectedValue(new NoVideoError('failed to get video track'))
+            const deps = createMockDeps({
+                getVideoFile: vi.fn().mockResolvedValue(fakeVideoFile),
+            })
+            const handler = new OffscreenHandler(deps)
+            await handler.handleMessage({ type: 'stop-recording', trigger: 'action-icon' })
 
-        expect(deps.recordingDB.put).toHaveBeenCalledWith(expect.objectContaining({ thumbnail: null }))
+            expect(deps.sendException).not.toHaveBeenCalled()
+            expect(consoleErrorSpy).not.toHaveBeenCalled()
+            expect(deps.recordingDB.put).toHaveBeenCalledWith(expect.objectContaining({ thumbnail: null }))
+        } finally {
+            consoleErrorSpy.mockRestore()
+        }
     })
 })
 

--- a/tests/thumbnail.test.ts
+++ b/tests/thumbnail.test.ts
@@ -23,7 +23,7 @@ vi.mock('mediabunny', () => {
     }
 })
 
-import { generateThumbnail } from '../src/thumbnail'
+import { generateThumbnail, NoVideoError } from '../src/thumbnail'
 
 function createFakeSample() {
     return {
@@ -96,7 +96,10 @@ describe('generateThumbnail', () => {
     it('throws when no video track found', async () => {
         mockGetPrimaryVideoTrack.mockResolvedValue(null)
 
-        await expect(generateThumbnail(new Blob())).rejects.toThrow('failed to get video track')
+        const error = await generateThumbnail(new Blob()).catch(e => e)
+
+        expect(error).toBeInstanceOf(NoVideoError)
+        expect(error).toHaveProperty('message', 'failed to get video track')
         expect(mockInputDispose).toHaveBeenCalled()
     })
 


### PR DESCRIPTION
This pull request introduces improved error handling for cases where video files do not contain a video track during thumbnail generation. A new custom error class, `NoVideoError`, is now used to distinguish this specific failure mode, and the offscreen handler is updated to handle it gracefully without logging unnecessary exceptions. Unit tests have also been updated to check for this new error type.

**Error handling improvements:**

* Added a new `NoVideoError` class to `src/thumbnail.ts` to represent failures when no video track is found in a video file.
* Modified `generateThumbnail` in `src/thumbnail.ts` to throw `NoVideoError` instead of a generic error when no video track is found.
* Updated imports in `src/offscreen_handler.ts` to include `NoVideoError`.
* In `OffscreenHandler` (`src/offscreen_handler.ts`), updated thumbnail generation error handling to skip logging and reporting when the error is a `NoVideoError`.

**Testing updates:**

* Updated `tests/thumbnail.test.ts` to import `NoVideoError` and added an assertion to verify that `generateThumbnail` rejects with `NoVideoError` when no video track is found. [[1]](diffhunk://#diff-18e4e2400b8ba8ac0e608e04499fd502eefcab54896bcb114c3ff251f0c63627L26-R26) [[2]](diffhunk://#diff-18e4e2400b8ba8ac0e608e04499fd502eefcab54896bcb114c3ff251f0c63627R99)