### PR TITLE
feat: add error handling for fetching recordings and service worker client claiming

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -495,6 +495,10 @@
         "message": "no entry",
         "description": "Message when no records exist"
     },
+    "recordListFetchError": {
+        "message": "Failed to load recordings. Please reload the page.",
+        "description": "Message when fetching recordings fails"
+    },
     "recordListTabAudio": {
         "message": "Tab audio",
         "description": "Label for tab audio sub-file"

--- a/extension/_locales/ja/messages.json
+++ b/extension/_locales/ja/messages.json
@@ -369,6 +369,9 @@
     "recordListNoEntry": {
         "message": "エントリなし"
     },
+    "recordListFetchError": {
+        "message": "録画一覧の取得に失敗しました。ページを再読み込みしてください。"
+    },
     "recordListTabAudio": {
         "message": "タブ音声"
     },

--- a/src/api_client.ts
+++ b/src/api_client.ts
@@ -1,6 +1,75 @@
 import type { RecordingMetadata, StorageEstimateInfo, ListRecordingsOptions } from './storage'
+import type { ClaimClientsMessage } from './message'
 
 const API_BASE = '/api'
+const CLAIM_TIMEOUT_MS = 2000
+
+let ensureControlledPromise: Promise<void> | null = null
+
+/**
+ * Ensure the page is controlled by the service worker.
+ * On hard reload, the page may lose SW control; this requests the SW to call clients.claim()
+ * and waits for the controllerchange event.
+ * Concurrent calls share the same in-flight promise so the claim is performed at most once.
+ */
+async function ensureControlled(): Promise<void> {
+    await navigator.serviceWorker.ready
+    if (navigator.serviceWorker.controller != null) return
+
+    if (ensureControlledPromise != null) {
+        await ensureControlledPromise
+        return
+    }
+
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    let onControllerChange: (() => void) | undefined
+
+    const cleanup = () => {
+        ensureControlledPromise = null
+        if (timeout !== undefined) {
+            clearTimeout(timeout)
+            timeout = undefined
+        }
+        if (onControllerChange !== undefined) {
+            navigator.serviceWorker.removeEventListener('controllerchange', onControllerChange)
+            onControllerChange = undefined
+        }
+    }
+
+    ensureControlledPromise = (async () => {
+        const controllerChanged = new Promise<void>((resolve, reject) => {
+            let settled = false
+            const resolveOnce = () => {
+                if (settled) return
+                settled = true
+                resolve()
+            }
+
+            timeout = setTimeout(() => {
+                if (settled) return
+                settled = true
+                reject(new Error('Timed out waiting for service worker to claim this client'))
+            }, CLAIM_TIMEOUT_MS)
+
+            onControllerChange = () => resolveOnce()
+            navigator.serviceWorker.addEventListener('controllerchange', onControllerChange, { once: true })
+
+            if (navigator.serviceWorker.controller != null) {
+                resolveOnce()
+            }
+        })
+
+        const msg: ClaimClientsMessage = { type: 'claim-clients' }
+        try {
+            await chrome.runtime.sendMessage(msg)
+            await controllerChanged
+        } finally {
+            cleanup()
+        }
+    })()
+
+    await ensureControlledPromise
+}
 
 /**
  * API client for recording storage operations
@@ -12,6 +81,7 @@ export class RecordingApiClient {
      * @param options - Optional listing options including sort order
      */
     async listRecordings(options?: ListRecordingsOptions): Promise<RecordingMetadata[]> {
+        await ensureControlled()
         const params = new URLSearchParams()
         if (options?.sort) {
             params.set('sort', options.sort)
@@ -29,6 +99,7 @@ export class RecordingApiClient {
      * Get the file blob for a recording
      */
     async getRecordingFile(name: string): Promise<Blob | null> {
+        await ensureControlled()
         const encodedName = encodeURIComponent(name)
         const response = await fetch(`${API_BASE}/recordings/${encodedName}`)
         if (response.status === 404) {
@@ -44,6 +115,7 @@ export class RecordingApiClient {
      * Delete a recording (idempotent, cascade deletes sub-files and IndexedDB record)
      */
     async deleteRecording(name: string): Promise<void> {
+        await ensureControlled()
         const encodedName = encodeURIComponent(name)
         const response = await fetch(`${API_BASE}/recordings/${encodedName}`, {
             method: 'DELETE',
@@ -60,6 +132,7 @@ export class RecordingApiClient {
      * Get storage estimate
      */
     async getStorageEstimate(): Promise<StorageEstimateInfo> {
+        await ensureControlled()
         const response = await fetch(`${API_BASE}/storage/estimate`)
         if (!response.ok) {
             throw new Error(`Failed to get storage estimate: ${response.status}`)

--- a/src/element/recordList.ts
+++ b/src/element/recordList.ts
@@ -203,6 +203,9 @@ export class RecordList extends LitElement {
     @state()
     private failedThumbnailKeys: Set<string> = new Set()
 
+    @state()
+    private fetchError: boolean = false
+
     private recordingStartAtMs: number | null = null
     private recordingStopAtMs: number | null = null
     private recordingPaused: boolean = false
@@ -428,9 +431,13 @@ export class RecordList extends LitElement {
                 </md-assist-chip>
             </md-chip-set>
             <md-list>
-                ${this.records.length === 0
-                    ? html`<md-list-item>${t('recordListNoEntry')}</md-list-item>`
-                    : repeat(this.records, record => record.path, row)}
+                ${this.fetchError
+                    ? html`<md-list-item style="--md-list-item-label-text-color: var(--theme-error, #b00020)">
+                          ${t('recordListFetchError')}
+                      </md-list-item>`
+                    : this.records.length === 0
+                      ? html`<md-list-item>${t('recordListNoEntry')}</md-list-item>`
+                      : repeat(this.records, record => record.path, row)}
             </md-list>`
     }
 
@@ -438,8 +445,23 @@ export class RecordList extends LitElement {
         this.records = this.records.filter(r => r.path !== record.path)
     }
     private async updateRecord() {
-        // Fetch recordings from API (now backed by IndexedDB, sub-files already grouped)
-        const recordings = await recordingApi.listRecordings({ sort: this.sortOrder })
+        let recordings: Awaited<ReturnType<typeof recordingApi.listRecordings>>
+        try {
+            // Fetch recordings from API (now backed by IndexedDB, sub-files already grouped)
+            recordings = await recordingApi.listRecordings({ sort: this.sortOrder })
+        } catch (e) {
+            console.error('Failed to fetch recordings:', e)
+            sendException(e, { exceptionSource: 'option.recordList.updateRecord' })
+            const oldVal = [...this.records]
+            this.fetchError = true
+            this.records = []
+            if (this.failedThumbnailKeys.size > 0) {
+                this.failedThumbnailKeys = new Set()
+            }
+            this.requestUpdate('records', oldVal)
+            return
+        }
+        this.fetchError = false
 
         const result: Array<RecordEntry> = recordings.map(meta => ({
             title: meta.title,

--- a/src/message.ts
+++ b/src/message.ts
@@ -28,6 +28,7 @@ export type Message =
     | TimerUpdatedMessage
     | ConfirmTimerStopMessage
     | UpdateRecordingTimerMessage
+    | ClaimClientsMessage
 
 export interface ExceptionMessage {
     type: 'exception'
@@ -165,4 +166,9 @@ export interface UpdateRecordingTimerMessage {
     type: 'update-recording-timer'
     enabled: boolean
     durationMinutes: number
+}
+
+// Request service worker to claim clients (option page → service_worker)
+export interface ClaimClientsMessage {
+    type: 'claim-clients'
 }

--- a/src/service_worker.ts
+++ b/src/service_worker.ts
@@ -461,6 +461,7 @@ const messageHandlerDeps: ServiceWorkerDeps = {
     updateActionTitle,
     resizeWindow,
     storageSyncSet: (key, value) => storage.set(key, value),
+    claimClients: () => self.clients.claim(),
 }
 
 chrome.runtime.onMessage.addListener(
@@ -524,4 +525,8 @@ self.addEventListener('fetch', (event: FetchEvent) => {
             })(),
         )
     }
+})
+
+self.addEventListener('activate', event => {
+    event.waitUntil(self.clients.claim())
 })

--- a/src/service_worker_handler.ts
+++ b/src/service_worker_handler.ts
@@ -16,6 +16,7 @@ export interface ServiceWorkerDeps {
     updateActionTitle: (state: RecordingState) => Promise<void>
     resizeWindow: (resolution: Resolution) => Promise<void>
     storageSyncSet: (key: string, value: object) => Promise<void>
+    claimClients: () => Promise<void>
 }
 
 export type HandleMessageResult = {
@@ -45,6 +46,8 @@ export function handleMessage(message: Message, deps: ServiceWorkerDeps): Handle
             return { response: handleFetchConfig(deps), fireAndForget: false }
         case 'request-recording-state':
             return { response: handleRequestRecordingState(deps), fireAndForget: true }
+        case 'claim-clients':
+            return { response: deps.claimClients(), fireAndForget: false }
     }
     return null
 }

--- a/tests/element/recordList.test.ts
+++ b/tests/element/recordList.test.ts
@@ -591,3 +591,77 @@ describe('record-list', () => {
         }
     })
 })
+
+describe('record-list fetch error', () => {
+    beforeEach(() => {
+        listRecordingsMock.mockReset()
+    })
+
+    test('renders fetch error message when listRecordings rejects', async () => {
+        listRecordingsMock.mockRejectedValue(new Error('network error'))
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const listItem = shadowQuery(el, 'md-list md-list-item')
+            expect(listItem?.textContent?.trim()).toBe('Failed to load recordings. Please reload the page.')
+        })
+    })
+
+    test('does not show "no entry" when listRecordings rejects', async () => {
+        listRecordingsMock.mockRejectedValue(new Error('network error'))
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const listItem = shadowQuery(el, 'md-list md-list-item')
+            expect(listItem?.textContent?.trim()).not.toBe('no entry')
+        })
+    })
+
+    test('error message uses error color style', async () => {
+        listRecordingsMock.mockRejectedValue(new Error('network error'))
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const listItem = shadowQuery(el, 'md-list md-list-item') as HTMLElement | null
+            expect(listItem?.style.getPropertyValue('--md-list-item-label-text-color')).toBe(
+                'var(--theme-error, #b00020)',
+            )
+        })
+    })
+
+    test('recovers from fetch error when next update succeeds', async () => {
+        listRecordingsMock.mockRejectedValueOnce(new Error('network error'))
+
+        const screen = render(html`<record-list></record-list>`)
+        const el = screen.container.querySelector('record-list')!
+        await elementUpdated(el)
+
+        // Wait for error state
+        await vi.waitFor(() => {
+            const listItem = shadowQuery(el, 'md-list md-list-item')
+            expect(listItem?.textContent?.trim()).toBe('Failed to load recordings. Please reload the page.')
+        })
+
+        // Simulate successful recording-state message triggering updateRecord
+        listRecordingsMock.mockResolvedValue([])
+        simulateChromeMessage({
+            type: 'recording-state',
+            data: { isRecording: false },
+        })
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const listItem = shadowQuery(el, 'md-list md-list-item')
+            expect(listItem?.textContent?.trim()).toBe('no entry')
+        })
+    })
+})

--- a/tests/service_worker_handler.test.ts
+++ b/tests/service_worker_handler.test.ts
@@ -26,6 +26,7 @@ function createMockDeps(overrides: Partial<ServiceWorkerDeps> = {}): ServiceWork
         updateActionTitle: vi.fn().mockResolvedValue(undefined),
         resizeWindow: vi.fn().mockResolvedValue(undefined),
         storageSyncSet: vi.fn().mockResolvedValue(undefined),
+        claimClients: vi.fn().mockResolvedValue(undefined),
         ...overrides,
     }
 }
@@ -207,6 +208,19 @@ describe('request-recording-state', () => {
         const result = handleMessage({ type: 'request-recording-state' }, deps)
         await result!.response
         expect(deps.broadcastRecordingState).toHaveBeenCalled()
+    })
+})
+
+// ---------- claim-clients ----------
+
+describe('claim-clients', () => {
+    it('calls claimClients and returns fireAndForget=false', async () => {
+        const deps = createMockDeps()
+        const result = handleMessage({ type: 'claim-clients' }, deps)
+        expect(result).not.toBeNull()
+        expect(result!.fireAndForget).toBe(false)
+        await result!.response
+        expect(deps.claimClients).toHaveBeenCalled()
     })
 })
 


### PR DESCRIPTION
This pull request improves the reliability and user experience of the recordings list by ensuring the page is always controlled by the service worker (even after a hard reload) and by providing clear error messaging when loading recordings fails. It also adds tests and refactors message handling for better maintainability.

**Service Worker Control and Messaging:**

* Added an `ensureControlled` function in `src/api_client.ts` to guarantee that the page is controlled by the service worker before making API requests, handling edge cases like hard reloads. [[1]](diffhunk://#diff-9b299787606a6d76f78401df55813147a35265cf7b8f8efe016a3c1c35bfc6ddR2-R33) [[2]](diffhunk://#diff-9b299787606a6d76f78401df55813147a35265cf7b8f8efe016a3c1c35bfc6ddR45)
* Introduced a new message type (`claim-clients`) and corresponding handler to request the service worker to call `clients.claim()` from the options page, ensuring proper control. [[1]](diffhunk://#diff-60ea006d358dc5cddec873646d6aaae8ee58e5dcee845e71069a25b99ba126bbR31) [[2]](diffhunk://#diff-60ea006d358dc5cddec873646d6aaae8ee58e5dcee845e71069a25b99ba126bbR170-R174) [[3]](diffhunk://#diff-3387c9a641bb064c8f2a7ab711fd42c52a69d02fe3ca71c99dd0a238b44e5bedR19) [[4]](diffhunk://#diff-3387c9a641bb064c8f2a7ab711fd42c52a69d02fe3ca71c99dd0a238b44e5bedR49-R50) [[5]](diffhunk://#diff-9a8dfe07c2bfeb25a7bcb4e293c44857c0bbbfc3417c31f1dc9d1d3482864216R464) [[6]](diffhunk://#diff-9a8dfe07c2bfeb25a7bcb4e293c44857c0bbbfc3417c31f1dc9d1d3482864216R529-R532)

**Error Handling and User Feedback:**

* Enhanced the recordings list UI (`src/element/recordList.ts`) to display a localized error message when fetching recordings fails, and added new error message strings for English and Japanese. [[1]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3R206-R208) [[2]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3L431-R438) [[3]](diffhunk://#diff-dea6f71f0c44b97d2a839ca7823249ca816ea17b0ace97cd46cfff532a03cdd3R448-R457) [[4]](diffhunk://#diff-6384fed49d960793ab61b9f71ac7fb91928ff924951e5f6431f883e854a643a7R498-R501) [[5]](diffhunk://#diff-5982590837dd44122bf0f35d85581d63a73a0f9f2c10cb334a76d0a7d7bb3d25R372-R374)

**Testing:**

* Added a unit test to verify that the new `claim-clients` message is handled correctly by the service worker handler. [[1]](diffhunk://#diff-54171ce1c0517fdb74c194d1cce54e430a0fe6e9ad9bf5ca856b9a75543a87b0R29) [[2]](diffhunk://#diff-54171ce1c0517fdb74c194d1cce54e430a0fe6e9ad9bf5ca856b9a75543a87b0R214-R226)