### PR TITLE
chore: restore min-release-age setting in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-# min-release-age=3
+min-release-age=3


### PR DESCRIPTION
This pull request makes a minor configuration change to the `.npmrc` file by uncommenting the `min-release-age` setting and setting its value to 3.