### PR TITLE
feat: add support for displaying license information

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -593,6 +593,18 @@
         "message": "Recording Failed",
         "description": "Alert headline when recording fails"
     },
+    "supportLicenses": {
+        "message": "License Information",
+        "description": "Support section: License heading"
+    },
+    "supportOpenSourceLicenses": {
+        "message": "Open Source Licenses",
+        "description": "Button to view open source licenses"
+    },
+    "supportLicenseLoadError": {
+        "message": "Failed to load license information.",
+        "description": "Error message when license file cannot be loaded"
+    },
     "supportReview": {
         "message": "Review",
         "description": "Support section: Review heading"

--- a/extension/_locales/ja/messages.json
+++ b/extension/_locales/ja/messages.json
@@ -444,6 +444,15 @@
     "recordListRecordingFailed": {
         "message": "録画に失敗しました"
     },
+    "supportLicenses": {
+        "message": "ライセンス情報"
+    },
+    "supportOpenSourceLicenses": {
+        "message": "オープンソースライセンス"
+    },
+    "supportLicenseLoadError": {
+        "message": "ライセンス情報の読み込みに失敗しました。"
+    },
     "supportReview": {
         "message": "レビュー"
     },

--- a/src/element/support.ts
+++ b/src/element/support.ts
@@ -140,6 +140,12 @@ export class Support extends LitElement {
         const isOverLimit = messageCharLength > MAX_MESSAGE_LENGTH
 
         return html`
+            <h2>${t('supportLicenses')}</h2>
+            <md-filled-tonal-button @click=${this.handleShowLicenses}>
+                ${t('supportOpenSourceLicenses')}
+                <md-icon slot="icon">description</md-icon>
+            </md-filled-tonal-button>
+
             <h2>${t('supportReview')}</h2>
             <div class="review-section">
                 <p>${t('supportReviewDescription')}</p>
@@ -275,6 +281,23 @@ export class Support extends LitElement {
 
     private handleReviewLink() {
         sendEvent({ type: 'click_external_link', tags: { link: 'review' } })
+    }
+
+    private async handleShowLicenses() {
+        const alertDialog = document.getElementById('alert-dialog') as Alert | null
+        if (!alertDialog) return
+
+        try {
+            const path = 'dist/dependencies-licenses.md'
+            const response = await fetch(path)
+            if (!response.ok) throw new Error(`failed to fetch ${path}: HTTP ${response.status}`)
+            const text = await response.text()
+            alertDialog.setContent(t('supportOpenSourceLicenses'), text, { preformatted: true })
+        } catch (e) {
+            alertDialog.setContent(t('alertDefaultHeadline'), t('supportLicenseLoadError'))
+            sendException(e, { exceptionSource: 'option.support.license' })
+        }
+        alertDialog.shadowRoot?.querySelector('md-dialog')?.show()
     }
 }
 

--- a/tests/element/support.test.ts
+++ b/tests/element/support.test.ts
@@ -1,6 +1,6 @@
 import { render } from 'vitest-browser-lit'
 import { html } from 'lit'
-import { describe, test, expect, vi } from 'vitest'
+import { describe, test, expect, vi, afterEach } from 'vitest'
 import { shadowQuery, shadowQueryAll, elementUpdated } from './test-helpers'
 
 // Mock sentry to avoid process.env references in browser
@@ -12,6 +12,7 @@ vi.mock('../../src/sentry', () => ({
 }))
 
 import '../../src/element/support'
+import '../../src/element/alert'
 
 describe('extension-support', () => {
     test('renders review section with Chrome Web Store link', async () => {
@@ -109,5 +110,102 @@ describe('extension-support', () => {
         const headings = shadowQueryAll(el, 'h2')
         const supportHeading = headings.find(h => h.textContent?.trim() === 'Support Development')
         expect(supportHeading).not.toBeUndefined()
+    })
+
+    describe('open source licenses button', () => {
+        let alertEl: HTMLElement
+
+        afterEach(() => {
+            vi.unstubAllGlobals()
+            alertEl?.remove()
+        })
+
+        test('renders license section with button', async () => {
+            const screen = render(html`<extension-support></extension-support>`)
+            const el = screen.container.querySelector('extension-support')!
+            await elementUpdated(el)
+
+            const headings = shadowQueryAll(el, 'h2')
+            const licenseHeading = headings.find(h => h.textContent?.trim() === 'License Information')
+            expect(licenseHeading).not.toBeUndefined()
+
+            // License heading should appear before Review heading
+            const headingTexts = headings.map(h => h.textContent?.trim())
+            const licenseIdx = headingTexts.indexOf('License Information')
+            const reviewIdx = headingTexts.indexOf('Review')
+            expect(licenseIdx).toBeLessThan(reviewIdx)
+        })
+
+        test('opens alert modal with license content on button click', async () => {
+            const licenseContent = '# Licenses\n\nMIT License\n\nCopyright (c) 2024'
+            const fetchMock = vi.fn().mockResolvedValue({
+                ok: true,
+                text: () => Promise.resolve(licenseContent),
+            })
+            vi.stubGlobal('fetch', fetchMock)
+
+            alertEl = document.createElement('extension-alert')
+            alertEl.id = 'alert-dialog'
+            document.body.appendChild(alertEl)
+
+            const screen = render(html`<extension-support></extension-support>`)
+            const el = screen.container.querySelector('extension-support')!
+            await elementUpdated(el)
+
+            // Find and click the license button (first md-filled-tonal-button without href)
+            const buttons = shadowQueryAll<HTMLElement>(el, 'md-filled-tonal-button')
+            const licenseBtn = buttons.find(
+                b => !b.hasAttribute('href') && b.textContent?.includes('Open Source Licenses'),
+            )
+            expect(licenseBtn).not.toBeUndefined()
+            licenseBtn!.click()
+
+            await vi.waitFor(() => {
+                expect(fetchMock).toHaveBeenCalledWith('dist/dependencies-licenses.md')
+                const dialog = alertEl.shadowRoot?.querySelector('md-dialog') as
+                    | (HTMLElement & { open?: boolean })
+                    | null
+                expect(dialog).not.toBeNull()
+                expect(dialog?.open).toBe(true)
+                const headline = alertEl.shadowRoot?.querySelector('[slot="headline"]')
+                expect(headline?.textContent).toBe('Open Source Licenses')
+                const content = alertEl.shadowRoot?.querySelector('[slot="content"] pre')
+                expect(content).not.toBeNull()
+                expect(content?.textContent).toBe(licenseContent)
+            })
+        })
+
+        test('shows error message when license fetch fails', async () => {
+            const fetchMock = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 404,
+            })
+            vi.stubGlobal('fetch', fetchMock)
+
+            alertEl = document.createElement('extension-alert')
+            alertEl.id = 'alert-dialog'
+            document.body.appendChild(alertEl)
+
+            const screen = render(html`<extension-support></extension-support>`)
+            const el = screen.container.querySelector('extension-support')!
+            await elementUpdated(el)
+
+            const buttons = shadowQueryAll<HTMLElement>(el, 'md-filled-tonal-button')
+            const licenseBtn = buttons.find(
+                b => !b.hasAttribute('href') && b.textContent?.includes('Open Source Licenses'),
+            )
+            licenseBtn!.click()
+
+            await vi.waitFor(() => {
+                expect(fetchMock).toHaveBeenCalledWith('dist/dependencies-licenses.md')
+                const dialog = alertEl.shadowRoot?.querySelector('md-dialog') as
+                    | (HTMLElement & { open?: boolean })
+                    | null
+                expect(dialog).not.toBeNull()
+                expect(dialog?.open).toBe(true)
+                const content = alertEl.shadowRoot?.querySelector('[slot="content"]')
+                expect(content?.textContent).toContain('Failed to load license information.')
+            })
+        })
     })
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,6 +53,7 @@ export default defineConfig(({ mode }) => ({
         sourcemap: !!process.env.SOURCEMAP,
         minify: mode === 'production',
         target: 'chrome140',
+        license: { fileName: 'dependencies-licenses.md' },
     },
     define: {
         'process.env.PKG_NAME': JSON.stringify(pkg.name),


### PR DESCRIPTION
This pull request adds a new "License Information" section to the Support page of the extension, allowing users to view open source license details. It introduces new UI elements, localization strings, and logic to fetch and display license information from a generated file. The build process is also updated to generate the necessary license file.

**Support page enhancements:**

* Added a "License Information" heading and a button labeled "Open Source Licenses" to the Support page UI, which opens a dialog displaying license information. (`src/element/support.ts`, [src/element/support.tsR143-R148](diffhunk://#diff-63d5e19d778540c181ca18a5ede44d7ebba9b5d343d430b2843bb2b17872c931R143-R148))
* Implemented the `handleShowLicenses` method to fetch and display the contents of `dist/dependencies-licenses.md` in a dialog, with error handling for failed fetches. (`src/element/support.ts`, [src/element/support.tsR285-R301](diffhunk://#diff-63d5e19d778540c181ca18a5ede44d7ebba9b5d343d430b2843bb2b17872c931R285-R301))

**Localization:**

* Added new localization strings for the license section and related error messages in both English and Japanese locale files. (`extension/_locales/en/messages.json`, [[1]](diffhunk://#diff-6384fed49d960793ab61b9f71ac7fb91928ff924951e5f6431f883e854a643a7R596-R607); `extension/_locales/ja/messages.json`, [[2]](diffhunk://#diff-5982590837dd44122bf0f35d85581d63a73a0f9f2c10cb334a76d0a7d7bb3d25R447-R455)

**Build process:**

* Updated the Vite build config to generate a `dependencies-licenses.md` file containing license information. (`vite.config.ts`, [vite.config.tsR56](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR56))