### PR TITLE
chore: update GitHub Actions runners from ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -26,7 +26,7 @@ defaults:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     environment:
       name: github-pages

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -52,7 +52,7 @@ jobs:
 
   test:
     needs: [lint]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -86,7 +86,7 @@ jobs:
 
   coverage:
     needs: [test]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       pull-requests: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -117,6 +117,18 @@ jobs:
         run: npm list
       - name: install dependencies
         run: npm ci
+      - id: playwright-version
+        name: Resolve Playwright version
+        run: |
+          echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ steps.playwright-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-playwright-
+            ${{ runner.os }}-playwright-
       - name: install Playwright Chromium
         run: npx playwright install --with-deps chromium
       - name: build

--- a/.github/workflows/upload-cws.yaml
+++ b/.github/workflows/upload-cws.yaml
@@ -15,7 +15,7 @@ jobs:
   upload:
     # Only run on bump/v* branches
     if: startsWith(github.ref, 'refs/heads/bump/v')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "marked": "^18.0.4",
         "oxfmt": "^0.51.0",
         "oxlint": "^1.66.0",
-        "playwright": "^1.59.1",
+        "playwright": "^1.60.0",
         "typescript": "^6.0.3",
         "vite": "^8.0.14",
         "vitest": "^4.1.5",
@@ -2706,13 +2706,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2725,9 +2725,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "marked": "^18.0.4",
     "oxfmt": "^0.51.0",
     "oxlint": "^1.66.0",
-    "playwright": "^1.59.1",
+    "playwright": "^1.60.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.14",
     "vitest": "^4.1.5",


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use a newer Ubuntu runner version and improves Playwright browser caching for CI. It also bumps the Playwright dependency to the latest version.

**CI/CD Environment Updates:**

* Updated all workflow jobs in `.github/workflows/pages.yaml`, `.github/workflows/release.yaml`, `.github/workflows/test.yaml`, and `.github/workflows/upload-cws.yaml` to use `ubuntu-24.04` instead of `ubuntu-22.04` for improved security and compatibility. [[1]](diffhunk://#diff-86eaae8c6d4108350f0ef9589ef2a19de3d6e3693eff3b89ee35c160ae35c21cL29-R29) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL18-R18) [[3]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L21-R21) [[4]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L55-R55) [[5]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L89-R89) [[6]](diffhunk://#diff-53862354b74b1b412fa0586d6c53b615c5d1fa5b17ebf8aa9fddc0b84997e3efL18-R18)

**CI Performance Improvements:**

* Added a step in the test workflow (`.github/workflows/test.yaml`) to cache Playwright browsers based on the resolved Playwright version, which speeds up CI runs by avoiding repeated downloads.

**Dependency Updates:**

* Upgraded the `playwright` package in `package.json` from version `^1.59.1` to `^1.60.0` for improved features and bug fixes.