### PR TITLE
feat(docs): add Japanese l10n and language switcher to index page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dist
 ## Project files
 extension.zip
 docs/dist/
+docs/ja/

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,12 +1,16 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="<%= lang %>">
 
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Instant Tab Recorder - Blazingly simple tab recorder</title>
-    <meta name="description" content="Record any Chrome tab with just one click. Simple, fast, and privacy-focused.">
-    <link rel="icon" type="image/png" href="icon128.png">
+    <title><%= title %></title>
+    <meta name="description" content="<%= description %>">
+    <link rel="icon" type="image/png" href="<%= basePath %>icon128.png">
+    <link rel="canonical" href="<%= canonicalUrl %>">
+    <link rel="alternate" hreflang="en" href="https://recorder.appcloud.info/">
+    <link rel="alternate" hreflang="ja" href="https://recorder.appcloud.info/ja/">
+    <link rel="alternate" hreflang="x-default" href="https://recorder.appcloud.info/">
     <style>
         /* Design 1: Minimal White */
         *,
@@ -87,6 +91,12 @@
             font-size: 18px;
         }
 
+        .header-right {
+            display: flex;
+            align-items: center;
+            gap: 24px;
+        }
+
         .header-links {
             display: flex;
             gap: 24px;
@@ -101,6 +111,42 @@
 
         .header-links a:hover {
             color: var(--accent);
+        }
+
+        .lang-switch {
+            display: flex;
+            align-items: center;
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            border-radius: 20px;
+            padding: 2px;
+            gap: 2px;
+        }
+
+        .lang-btn {
+            border: none;
+            background: transparent;
+            padding: 4px 10px;
+            border-radius: 16px;
+            font-size: 13px;
+            font-weight: 500;
+            color: var(--text-secondary);
+            cursor: pointer;
+            transition: all 0.2s ease;
+            line-height: 1.2;
+            text-decoration: none;
+            display: inline-block;
+        }
+
+        .lang-btn:hover {
+            color: var(--text-primary);
+        }
+
+        .lang-btn.active {
+            background: white;
+            color: var(--accent);
+            font-weight: 600;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
         }
 
         /* Hero */
@@ -238,48 +284,13 @@
             background: var(--bg-secondary);
         }
 
-        .privacy-tabs {
-            display: flex;
-            justify-content: center;
-            gap: 8px;
-            margin-bottom: 32px;
-        }
-
-        .privacy-tab {
-            padding: 10px 24px;
-            border: 1px solid var(--border);
-            background: white;
-            border-radius: 6px;
-            cursor: pointer;
-            font-size: 14px;
-            font-weight: 500;
-            color: var(--text-secondary);
-            transition: all 0.2s;
-        }
-
-        .privacy-tab:hover {
-            border-color: var(--accent);
-            color: var(--accent);
-        }
-
-        .privacy-tab.active {
-            background: var(--accent);
-            border-color: var(--accent);
-            color: white;
-        }
-
         .privacy-content {
-            display: none;
             background: white;
             border: 1px solid var(--border);
             border-radius: 12px;
             padding: 40px;
             max-height: 600px;
             overflow-y: auto;
-        }
-
-        .privacy-content.active {
-            display: block;
         }
 
         .privacy-content h1 {
@@ -417,31 +428,48 @@
     <!-- Header -->
     <header>
         <div class="container header-content">
-            <a href="./" class="logo" id="logo-link">
-                <img src="icon128.png" alt="Instant Tab Recorder">
+            <a href="<%= logoHref %>" class="logo" id="logo-link">
+                <img src="<%= basePath %>icon128.png" alt="Instant Tab Recorder">
                 <span>Instant Tab Recorder</span>
             </a>
-            <nav class="header-links">
-                <a href="#features">Features</a>
-                <a href="#how-to-use">How to Use</a>
-                <a href="#privacy">Privacy</a>
-            </nav>
+            <div class="header-right">
+                <nav class="header-links">
+                    <a href="#features">
+                        <span data-lang="en">Features</span>
+                        <span data-lang="ja">機能</span>
+                    </a>
+                    <a href="#how-to-use">
+                        <span data-lang="en">How to Use</span>
+                        <span data-lang="ja">使い方</span>
+                    </a>
+                    <a href="#privacy">
+                        <span data-lang="en">Privacy</span>
+                        <span data-lang="ja">プライバシーポリシー</span>
+                    </a>
+                </nav>
+                <div class="lang-switch">
+                    <a href="<%= enLink %>" class="lang-btn<%= enActive %>">English</a>
+                    <a href="<%= jaLink %>" class="lang-btn<%= jaActive %>">日本語</a>
+                </div>
+            </div>
         </div>
     </header>
 
     <!-- Hero -->
     <section class="hero">
         <div class="container">
-            <img src="icon128.png" alt="" class="hero-icon">
+            <img src="<%= basePath %>icon128.png" alt="" class="hero-icon">
             <h1>Instant Tab Recorder</h1>
-            <p class="tagline">Blazingly simple tab recorder.</p>
+            <p class="tagline" data-lang="en">Blazingly simple tab recorder.</p>
+            <p class="tagline" data-lang="ja">シンプルで高速なタブ録画ツール。</p>
             <a href="https://chromewebstore.google.com/detail/instant-tab-recorder/giebbnikpnedbdojlghnnegpfbgdecmi"
                 class="cta-button" target="_blank" rel="noopener">
                 <svg viewBox="0 0 24 24" fill="currentColor">
                     <path
                         d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z" />
                 </svg>
-                Add to Chrome
+                <span data-lang="en">Add to Chrome</span>
+                <span data-lang="ja">Chromeに追加</span>
             </a>
         </div>
     </section>
@@ -449,7 +477,10 @@
     <!-- Features -->
     <section class="features" id="features">
         <div class="container">
-            <h2 class="section-title">Features</h2>
+            <h2 class="section-title">
+                <span data-lang="en">Features</span>
+                <span data-lang="ja">機能</span>
+            </h2>
             <div class="features-grid">
                 <div class="feature">
                     <svg class="feature-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -457,9 +488,10 @@
                         <circle cx="12" cy="12" r="10"></circle>
                         <circle cx="12" cy="12" r="3"></circle>
                     </svg>
-                    <h3>Instant Recording</h3>
-                    <p>Start recording any Chrome tab instantly with a single click, context menu, or keyboard
-                        shortcut.</p>
+                    <h3 data-lang="en">Instant Recording</h3>
+                    <h3 data-lang="ja">即座に録画開始</h3>
+                    <p data-lang="en">Start recording any Chrome tab instantly with a single click, context menu, or keyboard shortcut.</p>
+                    <p data-lang="ja">ワンクリック、右クリックメニュー、またはキーボードショートカットで、Chromeのタブを即座に録画開始できます。</p>
                 </div>
                 <div class="feature">
                     <svg class="feature-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -467,8 +499,10 @@
                         <polygon points="23 7 16 12 23 17 23 7"></polygon>
                         <rect x="1" y="5" width="15" height="14" rx="2" ry="2"></rect>
                     </svg>
-                    <h3>Flexible Recording Modes</h3>
-                    <p>Choose from three modes: video with audio, video only, or audio only, to suit your needs.</p>
+                    <h3 data-lang="en">Flexible Recording Modes</h3>
+                    <h3 data-lang="ja">柔軟な録画モード</h3>
+                    <p data-lang="en">Choose from three modes: video with audio, video only, or audio only, to suit your needs.</p>
+                    <p data-lang="ja">用途に合わせて「音声付き動画」「動画のみ」「音声のみ」の3つのモードから選択できます。</p>
                 </div>
                 <div class="feature">
                     <svg class="feature-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -478,9 +512,10 @@
                         <line x1="12" y1="19" x2="12" y2="23"></line>
                         <line x1="8" y1="23" x2="16" y2="23"></line>
                     </svg>
-                    <h3>Microphone & Audio Separation</h3>
-                    <p>Add microphone audio to your recording. Optionally save tab and mic audio as separate files for
-                        transcription or post-processing.</p>
+                    <h3 data-lang="en">Microphone & Audio Separation</h3>
+                    <h3 data-lang="ja">マイク音声・音声を分離</h3>
+                    <p data-lang="en">Add microphone audio to your recording. Optionally save tab and mic audio as separate files for transcription or post-processing.</p>
+                    <p data-lang="ja">録画にマイク音声を追加できます。タブの音声とマイク音声を別ファイルとして保存することもでき、文字起こしや後編集に便利です。</p>
                 </div>
                 <div class="feature">
                     <svg class="feature-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -494,9 +529,10 @@
                         <line x1="17" y1="17" x2="22" y2="17"></line>
                         <line x1="17" y1="7" x2="22" y2="7"></line>
                     </svg>
-                    <h3>Cropping & Window Resize</h3>
-                    <p>Crop a portion of the visible area or resize the browser window to a specific dimension before
-                        recording.</p>
+                    <h3 data-lang="en">Cropping & Window Resize</h3>
+                    <h3 data-lang="ja">クロップ・ウィンドウサイズ変更</h3>
+                    <p data-lang="en">Crop a portion of the visible area or resize the browser window to a specific dimension before recording.</p>
+                    <p data-lang="ja">表示領域の一部をクロップしたり、録画前にブラウザウィンドウを指定のサイズにリサイズできます。</p>
                 </div>
                 <div class="feature">
                     <svg class="feature-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -506,9 +542,10 @@
                             d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z">
                         </path>
                     </svg>
-                    <h3>Customizable Settings</h3>
-                    <p>Configure resolution, bitrate, format, and codec. Wide range of codecs including H.265, AV1,
-                        AAC, FLAC, and more.</p>
+                    <h3 data-lang="en">Customizable Settings</h3>
+                    <h3 data-lang="ja">柔軟な設定カスタマイズ</h3>
+                    <p data-lang="en">Configure resolution, bitrate, format, and codec. Wide range of codecs including H.265, AV1, AAC, FLAC, and more.</p>
+                    <p data-lang="ja">解像度、ビットレート、フォーマット、コーデックを設定可能。H.265、AV1、AAC、FLACなど幅広いコーデックに対応しています。</p>
                 </div>
                 <div class="feature">
                     <svg class="feature-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -521,8 +558,10 @@
                         <path d="M8.53 16.11a6 6 0 0 1 6.95 0"></path>
                         <line x1="12" y1="20" x2="12.01" y2="20"></line>
                     </svg>
-                    <h3>Works Offline</h3>
-                    <p>No internet connection required. All recording and processing happens locally on your device.</p>
+                    <h3 data-lang="en">Works Offline</h3>
+                    <h3 data-lang="ja">オフライン対応</h3>
+                    <p data-lang="en">No internet connection required. All recording and processing happens locally on your device.</p>
+                    <p data-lang="ja">インターネット接続は不要です。すべての録画および処理はお使いのデバイス上でローカルに行われます。</p>
                 </div>
             </div>
         </div>
@@ -531,27 +570,36 @@
     <!-- How to Use -->
     <section id="how-to-use">
         <div class="container">
-            <h2 class="section-title">How to Use</h2>
+            <h2 class="section-title">
+                <span data-lang="en">How to Use</span>
+                <span data-lang="ja">使い方</span>
+            </h2>
             <div class="steps">
                 <div class="step">
                     <div class="step-number">1</div>
                     <div class="step-content">
-                        <h3>Install the Extension</h3>
-                        <p>Add Instant Tab Recorder to Chrome from the Chrome Web Store.</p>
+                        <h3 data-lang="en">Install the Extension</h3>
+                        <h3 data-lang="ja">拡張機能をインストール</h3>
+                        <p data-lang="en">Add Instant Tab Recorder to Chrome from the Chrome Web Store.</p>
+                        <p data-lang="ja">Chrome ウェブストアから Instant Tab Recorder を Chrome に追加します。</p>
                     </div>
                 </div>
                 <div class="step">
                     <div class="step-number">2</div>
                     <div class="step-content">
-                        <h3>Click to Record</h3>
-                        <p>Click the extension icon, use the context menu, or press a keyboard shortcut to begin.</p>
+                        <h3 data-lang="en">Click to Record</h3>
+                        <h3 data-lang="ja">クリックして録画開始</h3>
+                        <p data-lang="en">Click the extension icon, use the context menu, or press a keyboard shortcut to begin.</p>
+                        <p data-lang="ja">拡張機能のアイコンをクリックするか、コンテキストメニュー、またはショートカットキーを押して録画を開始します。</p>
                     </div>
                 </div>
                 <div class="step">
                     <div class="step-number">3</div>
                     <div class="step-content">
-                        <h3>Save & Share</h3>
-                        <p>Stop the recording and download it in WebM or MP4 format.</p>
+                        <h3 data-lang="en">Save & Share</h3>
+                        <h3 data-lang="ja">保存・共有</h3>
+                        <p data-lang="en">Stop the recording and download it in WebM or MP4 format.</p>
+                        <p data-lang="ja">録画を停止し、WebMまたはMP4形式でダウンロードします。</p>
                     </div>
                 </div>
             </div>
@@ -561,13 +609,12 @@
     <!-- Privacy Policy -->
     <section class="privacy" id="privacy">
         <div class="container">
-            <h2 class="section-title">Privacy Policy</h2>
-            <div class="privacy-tabs">
-                <button class="privacy-tab active" data-lang="en">English</button>
-                <button class="privacy-tab" data-lang="ja">日本語</button>
-            </div>
+            <h2 class="section-title">
+                <span data-lang="en">Privacy Policy</span>
+                <span data-lang="ja">プライバシーポリシー</span>
+            </h2>
 
-            <div class="privacy-content active" data-lang="en" id="privacy-en">
+            <div class="privacy-content" data-lang="en" id="privacy-en">
                 <%= privacyEn %>
             </div>
             <div class="privacy-content" data-lang="ja" id="privacy-ja">
@@ -602,7 +649,7 @@
         </div>
     </footer>
 
-    <script type="module" src="src/site.ts"></script>
+    <script type="module" src="<%= basePath %>src/site.ts"></script>
 </body>
 
 </html>

--- a/docs/src/site.ts
+++ b/docs/src/site.ts
@@ -1,29 +1,10 @@
-// Privacy Policy Tab Switching
-document.querySelectorAll<HTMLButtonElement>('.privacy-tab').forEach(tab => {
-    tab.addEventListener('click', () => {
-        const lang = tab.dataset.lang
-
-        // Update tabs
-        document.querySelectorAll('.privacy-tab').forEach(t => t.classList.remove('active'))
-        tab.classList.add('active')
-
-        // Update content
-        document.querySelectorAll<HTMLElement>('.privacy-content').forEach(content => {
-            content.classList.remove('active')
-            if (content.dataset.lang === lang) {
-                content.classList.add('active')
-            }
-        })
-    })
-})
-
 // SPA-like navigation for logo link using History API
 document.getElementById('logo-link')?.addEventListener('click', e => {
     e.preventDefault()
     // Update URL without page reload
     const basePath = window.location.pathname + window.location.search
     if (window.location.hash) {
-        history.pushState(null, '', basePath || '/')
+        history.pushState(null, '', basePath)
     }
     // Smooth scroll to top
     window.scrollTo({ top: 0, behavior: 'smooth' })

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,9 +1,13 @@
-import { readFileSync } from 'fs'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import path from 'path'
 import { defineConfig, Plugin } from 'vite'
 import { marked } from 'marked'
 
 const docsDir = import.meta.dirname
+const indexHtmlPath = path.resolve(docsDir, 'index.html')
+const jaDir = path.resolve(docsDir, 'ja')
+const jaIndexHtmlPath = path.resolve(jaDir, 'index.html')
+
 const privacyMdFiles = {
     en: path.resolve(docsDir, 'PRIVACY.md'),
     ja: path.resolve(docsDir, 'PRIVACY_JA.md'),
@@ -29,19 +33,76 @@ function renderPrivacyPage(templateHtml: string, page: (typeof privacyPages)[num
         .replace(/<%=\s*content\s*%>/g, () => content)
 }
 
+const PAGE_CONFIG = {
+    en: {
+        lang: 'en',
+        title: 'Instant Tab Recorder - Blazingly simple tab recorder',
+        description: 'Record any Chrome tab with just one click. Simple, fast, and privacy-focused.',
+        canonicalUrl: 'https://recorder.appcloud.info/',
+        basePath: './',
+        logoHref: './',
+        enLink: './',
+        jaLink: './ja/',
+        enActive: ' active',
+        jaActive: '',
+    },
+    ja: {
+        lang: 'ja',
+        title: 'Instant Tab Recorder - シンプルで高速なタブ録画ツール',
+        description: 'ワンクリックでChromeのタブを録画。シンプル、高速、そしてプライバシーに配慮。',
+        canonicalUrl: 'https://recorder.appcloud.info/ja/',
+        basePath: '../',
+        logoHref: '../ja/',
+        enLink: '../',
+        jaLink: './',
+        enActive: '',
+        jaActive: ' active',
+    },
+}
+
+function renderLpPage(templateHtml: string, lang: 'en' | 'ja'): string {
+    const config = PAGE_CONFIG[lang]
+    const vars = loadPrivacy()
+
+    // 1. Remove opposite language data-lang blocks
+    const targetRemoveLang = lang === 'en' ? 'ja' : 'en'
+    const removeRegex = new RegExp(`<\\w+[^>]*\\bdata-lang="${targetRemoveLang}"[^>]*>[\\s\\S]*?<\\/\\w+>`, 'gi')
+    let result = templateHtml.replace(removeRegex, '')
+
+    // 2. Clean up current language data-lang attribute
+    result = result.replace(new RegExp(`\\s*data-lang="${lang}"`, 'g'), '')
+
+    // 3. Render privacy placeholders
+    result = result
+        .replace(/<%=\s*privacyEn\s*%>/g, () => vars.privacyEn)
+        .replace(/<%=\s*privacyJa\s*%>/g, () => vars.privacyJa)
+
+    // 4. Replace page configuration variables
+    result = result.replace(/<%=\s*(\w+)\s*%>/g, (_, key) => {
+        return config[key as keyof typeof config] ?? ''
+    })
+
+    return result
+}
+
+function buildLocalizedHtmlInput() {
+    // Generate temporary ja/index.html so Vite natively outputs to dist/ja/index.html
+    if (!existsSync(jaDir)) {
+        mkdirSync(jaDir, { recursive: true })
+    }
+    const rawTemplate = readFileSync(indexHtmlPath, 'utf-8')
+    writeFileSync(jaIndexHtmlPath, rawTemplate, 'utf-8')
+
+    return {
+        main: indexHtmlPath,
+        ja: jaIndexHtmlPath,
+    }
+}
+
 function docsPlugin(): Plugin[] {
     const buildPlugin: Plugin = {
         name: 'docs-build',
         apply: 'build',
-        transformIndexHtml: {
-            order: 'pre',
-            handler(html) {
-                const vars = loadPrivacy()
-                return html.replace(/<%=\s*(\w+)\s*%>/g, (_, key) => {
-                    return (vars as Record<string, string>)[key] ?? ''
-                })
-            },
-        },
         buildStart() {
             const vars = loadPrivacy()
             const templateHtml = readFileSync(privacyTemplate, 'utf-8')
@@ -58,6 +119,19 @@ function docsPlugin(): Plugin[] {
             const iconData = readFileSync(path.resolve(docsDir, '..', 'extension/icons/icon128.png'))
             this.emitFile({ type: 'asset', fileName: 'icon128.png', source: iconData })
         },
+        transformIndexHtml: {
+            order: 'pre',
+            handler(html, ctx) {
+                const isJa = ctx?.filename?.includes('/ja/')
+                return renderLpPage(html, isJa ? 'ja' : 'en')
+            },
+        },
+        closeBundle() {
+            // Clean up temporary ja source directory after build
+            if (existsSync(jaDir)) {
+                rmSync(jaDir, { recursive: true, force: true })
+            }
+        },
     }
 
     const servePlugin: Plugin = {
@@ -65,11 +139,11 @@ function docsPlugin(): Plugin[] {
         apply: 'serve',
         transformIndexHtml: {
             order: 'pre',
-            handler(html) {
-                const vars = loadPrivacy()
-                return html.replace(/<%=\s*(\w+)\s*%>/g, (_, key) => {
-                    return (vars as Record<string, string>)[key] ?? ''
-                })
+            handler(html, ctx) {
+                if (ctx?.filename?.includes('/ja/')) {
+                    return renderLpPage(html, 'ja')
+                }
+                return renderLpPage(html, 'en')
             },
         },
         configureServer(server) {
@@ -80,7 +154,6 @@ function docsPlugin(): Plugin[] {
                     const vars = loadPrivacy()
                     const templateHtml = readFileSync(privacyTemplate, 'utf-8')
                     const html = renderPrivacyPage(templateHtml, match, vars[match.contentKey])
-                    // Inject Vite HMR client for hot reload
                     const injected = html.replace(
                         '</head>',
                         '  <script type="module" src="/@vite/client"></script>\n</head>',
@@ -98,15 +171,14 @@ function docsPlugin(): Plugin[] {
                 }
                 next()
             })
-            // Watch markdown files and privacy template for reload
-            server.watcher.add([privacyMdFiles.en, privacyMdFiles.ja, privacyTemplate])
+            server.watcher.add([privacyMdFiles.en, privacyMdFiles.ja, privacyTemplate, indexHtmlPath])
             server.watcher.on('change', changedPath => {
-                if (
-                    changedPath === privacyMdFiles.en ||
-                    changedPath === privacyMdFiles.ja ||
-                    changedPath === privacyTemplate
-                ) {
-                    server.ws.send({ type: 'full-reload' })
+                switch (changedPath) {
+                    case privacyMdFiles.en:
+                    case privacyMdFiles.ja:
+                    case privacyTemplate:
+                    case indexHtmlPath:
+                        server.ws.send({ type: 'full-reload' })
                 }
             })
         },
@@ -117,6 +189,7 @@ function docsPlugin(): Plugin[] {
 
 export default defineConfig({
     root: docsDir,
+    input: buildLocalizedHtmlInput(),
     server: {
         port: 8080,
     },


### PR DESCRIPTION
This pull request adds multi-language (English and Japanese) support to the landing page and privacy policy, improves SEO and accessibility, and simplifies the language switching experience. The most important changes are grouped below.

**Internationalization and Language Switching:**
* All major UI sections in `docs/index.html` now support both English and Japanese, using `data-lang` attributes to display the appropriate language. Language switching is handled by static links instead of client-side tab toggling. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL420-R505) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL481-R518) [[3]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL497-R535) [[4]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL509-R548) [[5]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL524-R564) [[6]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL534-R602) [[7]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL564-R617) [[8]](diffhunk://#diff-4af75c3b0b86f47bce2f676eb3973ba1838c211f3f1bdb0c77cb14d4843c3411R32-R101)
* A new language switcher UI is added to the header, and language-specific navigation and content are rendered at build time. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeR94-R99) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeR116-R151) [[3]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL420-R505) [[4]](diffhunk://#diff-4af75c3b0b86f47bce2f676eb3973ba1838c211f3f1bdb0c77cb14d4843c3411R32-R101)

**SEO and Metadata Improvements:**
* The `<html>` tag, `<title>`, `<meta name="description">`, favicon path, canonical URLs, and alternate language links are now dynamically set based on the selected language, improving SEO and discoverability. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL2-R13) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL420-R505)

**Build Process and Code Simplification:**
* The Vite build config (`docs/vite.config.ts`) now generates separate, fully static `index.html` files for English and Japanese, removing the need for client-side language toggling for the privacy policy.
* The privacy policy tab switching JavaScript and related CSS are removed, since language selection is now handled by static pages. [[1]](diffhunk://#diff-076324a21a59970681b59cd25897739a8e2ff2606beb9c8b82b449c992cdbf64L1-R7) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL241-L272) [[3]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL281-L284) [[4]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL564-R617)

**Path Handling:**
* All asset and script paths (favicon, images, JS) are now dynamically set using a base path variable to ensure correct loading for both language versions. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL2-R13) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL420-R505) [[3]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL605-R652)

Overall, these changes make the site fully localized, improve SEO, and simplify both the codebase and the user experience for language selection.